### PR TITLE
Improvements

### DIFF
--- a/alembic/versions/add_video_request_type.py
+++ b/alembic/versions/add_video_request_type.py
@@ -17,7 +17,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TYPE requesttype ADD VALUE IF NOT EXISTS 'video'")
+    op.execute("ALTER TYPE requesttype ADD VALUE IF NOT EXISTS 'VIDEO'")
 
 
 def downgrade() -> None:

--- a/alembic/versions/add_video_request_type.py
+++ b/alembic/versions/add_video_request_type.py
@@ -1,0 +1,24 @@
+"""Add video request type
+
+Revision ID: add_video_request_type
+Revises: optimize_process_artifacts
+Create Date: 2026-06-20 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'add_video_request_type'
+down_revision: Union[str, None] = 'optimize_process_artifacts'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE requesttype ADD VALUE IF NOT EXISTS 'video'")
+
+
+def downgrade() -> None:
+    pass

--- a/app/auth.py
+++ b/app/auth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, UTC
 from typing import Optional
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import bcrypt
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
@@ -14,7 +14,11 @@ from app.settings import get_settings
 
 settings = get_settings()
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
+bearer_scheme = HTTPBearer(
+    scheme_name="BearerAuth",
+    bearerFormat="JWT",
+    description="JWT access token from POST /auth/token",
+)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -48,7 +52,11 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt
 
-async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(database.get_db)):
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(database.get_db),
+):
+    token = credentials.credentials
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",

--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,12 @@ static_ffmpeg.add_paths()
 
 settings = Settings()
 
-app = FastAPI()
+API_DOCS_KWARGS = {
+    "title": "Transition Summarize API",
+    "swagger_ui_parameters": {"persistAuthorization": True},
+}
+
+app = FastAPI(**API_DOCS_KWARGS)
 
 # Initialize scheduler
 init_scheduler(app)
@@ -41,7 +46,10 @@ if settings.cleanup_downloads_enabled:
 app.add_middleware(RequestIDMiddleware)
 
 # Create a new router for protected routes
-protected_app = FastAPI(dependencies=[Depends(get_current_active_user)])
+protected_app = FastAPI(
+    dependencies=[Depends(get_current_active_user)],
+    **API_DOCS_KWARGS,
+)
 
 # Include routers in the protected app
 protected_app.include_router(a_router)

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.routers.audio import a_router
 from app.routers.auth import auth_router
 from app.routers.youtube import yt_router
 from app.routers.artifacts import router as artifacts_router
+from app.routers.video import video_router
 from app.schema import models
 from app.settings import Settings, get_settings
 from app.database import init_db
@@ -47,6 +48,7 @@ protected_app.include_router(a_router)
 protected_app.include_router(yt_router)
 protected_app.include_router(artifacts_router)
 protected_app.include_router(artifacts_router)
+protected_app.include_router(video_router)
 
 # Include the protected app and auth router in the main app
 app.mount("/api", protected_app)
@@ -54,6 +56,7 @@ app.include_router(auth_router)
 app.include_router(yt_router)
 app.include_router(a_router)
 app.include_router(artifacts_router)
+app.include_router(video_router)
 
 # Configure logging with request ID
 logger = logging.getLogger()

--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,7 @@ class ApiProcessingResult(BaseModel):
     text: Optional[str] = Field(default=None, title="Video transcription")
     transcription: Optional[str] = Field(default=None, title="Transcription text")
     format: Optional[WHISPER_RESPONSE_FORMAT] = Field(default=None, title="Response format")
+    metadata: Optional[dict] = Field(default=None, title="Video metadata (title, description, duration, etc.)")
 
 
 class YtVideoInfoRequest(BaseModel):
@@ -91,6 +92,7 @@ class YtVideoSummarize(BaseModel):
 
 class SummaryResult(BaseModel):
     summary: str
+    metadata: Optional[dict] = Field(default=None, title="Video metadata (title, description, duration, etc.)")
 
 
 class YoutubeTranscriptionMetadata(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -126,6 +126,93 @@ class YoutubeMetadata(BaseModel):
         None, description="The URL of the video thumbnail image")
 
 
+class VideoMetadata(BaseModel):
+    title: str = Field(
+        default="", description="The title of the video")
+    full_title: Optional[str] = Field(None,
+        description="The full title of the video")
+    description: str = Field(
+        default="", description="The description of the video")
+    duration: Optional[float] = Field(
+        None, description="The duration of the video in seconds")
+    duration_string: Optional[str] = Field(None,
+        description="A human-readable string representation of the video duration")
+    uploader: Optional[str] = Field(
+        None, description="Name of the uploader/channel")
+    uploader_url: Optional[str] = Field(
+        None, description="URL of the uploader/channel page")
+    platform: Optional[str] = Field(
+        None, description="Name of the platform (e.g. vimeo, instagram)")
+    original_url: Optional[str] = Field(
+        None, description="The original URL of the video")
+    upload_date: Optional[datetime] = Field(
+        None, description="The date when the video was uploaded")
+    thumbnail: Optional[str] = Field(
+        None, description="The URL of the video thumbnail image")
+    language: Optional[str] = Field(
+        None, description="The primary language of the video content")
+    subtitles: dict[str, dict[str, YoutubeTranscriptionMetadata]] = Field(
+        default_factory=dict,
+        description="Available subtitles organized by language and format")
+    available_transcriptions: List[str] = Field(
+        default_factory=list,
+        description="List of available transcription languages")
+
+
+class VideoTranscribe(BaseModel):
+    url: str
+    lang: LANG_CODE = Field(default=LANG_CODE.POLISH,
+                            title="Video language as ISO-639-1 code like PL, EN")
+    response_format: WHISPER_RESPONSE_FORMAT = Field(
+        default=WHISPER_RESPONSE_FORMAT.SRT, title="Response format")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789",
+                    "lang": "en",
+                    "response_format": "srt"
+                }
+            ]
+        }
+    }
+
+
+class VideoSummarize(BaseModel):
+    url: str
+    type: SUMMARIZATION_TYPE = Field(
+        default=SUMMARIZATION_TYPE.TLDR, title="Type of summarization")
+    lang: LANG_CODE = Field(default=LANG_CODE.POLISH,
+                            title="Language code of transcription and final summarization text")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789",
+                    "type": "detailed",
+                    "lang": "en"
+                }
+            ]
+        }
+    }
+
+
+class VideoInfoRequest(BaseModel):
+    url: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789"
+                }
+            ]
+        }
+    }
+
+
 class Token(BaseModel):
     access_token: str
     token_type: str

--- a/app/processing/processing.py
+++ b/app/processing/processing.py
@@ -22,6 +22,8 @@ def register_new_process(user: User, request_type: RequestType, request: Request
                 source_type = UserProcessSourceType.URL
             case RequestType.YOUTUBE:
                 source_type = UserProcessSourceType.URL
+            case RequestType.VIDEO:
+                source_type = UserProcessSourceType.URL
             case _:
                 raise ValueError(f"Invalid request type: {request_type}")
 

--- a/app/routers/video.py
+++ b/app/routers/video.py
@@ -1,0 +1,261 @@
+import hashlib
+import logging
+
+from fastapi import APIRouter, Request, Depends, Response, status
+from fastapi.responses import FileResponse
+from starlette.responses import PlainTextResponse
+
+from app.auth import get_current_active_user
+from app.models import (
+    VideoTranscribe, VideoSummarize, VideoInfoRequest,
+    VideoMetadata, SummaryResult, ApiProcessingResult,
+)
+from app.processing.processing import (
+    complete_process, process_failed, register_new_process,
+    register_process_artifact, update_process_status,
+)
+from app.schema.models import ProcessArtifactFormat, ProcessArtifactType, RequestStatus, RequestType
+from app.schema.pydantic_models import CompletedProcess, User
+from app.summary.summarization import summarize
+from app.transcribe.transcription import WHISPER_RESPONSE_FORMAT
+from app.video.metadata import get_video_metadata
+from app.video.transcription import video_transcribe
+
+video_router = APIRouter(
+    prefix="/video",
+    tags=["video", "transcription", "summarization"],
+    dependencies=[Depends(get_current_active_user)]
+)
+
+
+def save_dir_path(url: str) -> str:
+    hash_object = hashlib.md5(url.encode())
+    hash_hex = hash_object.hexdigest()
+    return f"./downloads/video/{hash_hex}/"
+
+
+@video_router.post(
+    "/transcribe",
+    response_model=ApiProcessingResult,
+    responses={
+        200: {
+            "description": "Transcription result. Content type depends on the `Accept` request header.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": True, "error": None, "transcription": "Hello world", "format": "srt"},
+                },
+                "text/plain": {
+                    "schema": {"type": "string"},
+                    "example": "Hello world",
+                },
+            },
+        },
+        500: {
+            "description": "Internal server error during transcription.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Internal server error: <details>", "text": None},
+                }
+            },
+        },
+    },
+)
+def video_transcription(
+        request: Request,
+        video_request: VideoTranscribe,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video transcribe - request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            request_type=RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        save_dir = save_dir_path(video_request.url)
+        transcription = video_transcribe(
+            video_request.url,
+            save_dir,
+            video_request.lang,
+            video_request.response_format)
+
+        update_process_status(process_id, CompletedProcess(
+            user_id=current_user.id,
+            status=RequestStatus.COMPLETED,
+            result=transcription,
+            result_format=ProcessArtifactFormat.TEXT,
+            lang=video_request.lang,
+            type=ProcessArtifactType.TRANSCRIPTION
+        ))
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(transcription)
+        else:
+            return ApiProcessingResult(
+                result=True, error=None,
+                transcription=transcription,
+                format=video_request.response_format)
+    except Exception as e:
+        logging.error(f"Error processing video transcription: {str(e)}")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Internal server error: {str(e)}",
+        )
+
+
+@video_router.post(
+    "/summarize",
+    response_model=SummaryResult,
+    responses={
+        200: {
+            "description": "Summarization result. Content type depends on the `Accept` request header.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/SummaryResult"},
+                    "example": {"summary": "The video covers the main highlights..."},
+                },
+                "text/plain": {
+                    "schema": {"type": "string"},
+                    "example": "The video covers the main highlights...",
+                },
+                "text/srt": {
+                    "schema": {"type": "string", "format": "binary"},
+                    "example": "1\n00:00:01,000 --> 00:00:05,000\nHello world",
+                },
+            },
+        },
+        500: {
+            "description": "Internal server error during transcription or summarization.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Error processing video summarization", "text": "<details>"},
+                }
+            },
+        },
+    },
+)
+def video_summarize(
+        request: Request,
+        video_request: VideoSummarize,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video summarize - Request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        save_dir = save_dir_path(video_request.url)
+
+        transcription = video_transcribe(
+            video_request.url, save_dir, video_request.lang,
+            WHISPER_RESPONSE_FORMAT.TEXT)
+
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.TRANSCRIPTION,
+            transcription,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        summarization = summarize(
+            transcription, video_request.type, video_request.lang)
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.SUMMARY,
+            summarization,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        logging.debug(f"video summarize - Result: \n{summarization}")
+
+        complete_process(process_id)
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(summarization)
+        elif accept_header == "text/srt":
+            return FileResponse(transcription, media_type="text/srt")
+        else:
+            return SummaryResult(summary=summarization)
+    except Exception as e:
+        logging.error(f"Error processing video summarization: '{str(e)}'")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error="Error processing video summarization",
+            text=str(e))
+
+
+@video_router.post(
+    "/details",
+    response_model=VideoMetadata | ApiProcessingResult,
+    responses={
+        200: {
+            "description": "Video metadata.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/VideoMetadata"},
+                    "example": {
+                        "title": "Example Video",
+                        "duration": 120.0,
+                        "duration_string": "2:00",
+                        "description": "Video description here.",
+                        "platform": "Vimeo",
+                        "uploader": "Example User",
+                    },
+                }
+            },
+        },
+        500: {
+            "description": "Internal server error while fetching video metadata.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Error extracting video details: <details>", "text": "<details>"},
+                }
+            },
+        },
+    },
+)
+def video_details(
+        request: VideoInfoRequest,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    try:
+        logging.info(f"Getting video details: {request.url}")
+
+        metadata = get_video_metadata(request.url)
+
+        return metadata
+    except Exception as e:
+        logging.error(f"Error fetching video details: {str(e)}")
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Error extracting video details: {str(e)}",
+            text=str(e))

--- a/app/routers/video.py
+++ b/app/routers/video.py
@@ -34,6 +34,44 @@ def save_dir_path(url: str) -> str:
     return f"./downloads/video/{hash_hex}/"
 
 
+def _trim_metadata_text(text: str, max_length: int = 2000) -> str:
+    cleaned_text = " ".join(text.split())
+    if len(cleaned_text) <= max_length:
+        return cleaned_text
+
+    return f"{cleaned_text[:max_length].rstrip()}..."
+
+
+def build_video_summary_input(
+        transcription: str,
+        metadata: VideoMetadata | None
+) -> str:
+    if not metadata:
+        return transcription
+
+    metadata_lines = []
+    if metadata.title:
+        metadata_lines.append(f"Title: {metadata.title}")
+    if metadata.duration_string:
+        metadata_lines.append(f"Duration: {metadata.duration_string}")
+    elif metadata.duration:
+        metadata_lines.append(f"Duration: {metadata.duration} seconds")
+    if metadata.description:
+        metadata_lines.append(
+            f"Description: {_trim_metadata_text(metadata.description)}")
+
+    if not metadata_lines:
+        return transcription
+
+    return "\n".join([
+        "Video metadata:",
+        *metadata_lines,
+        "",
+        "Transcript:",
+        transcription
+    ])
+
+
 @video_router.post(
     "/transcribe",
     response_model=ApiProcessingResult,
@@ -167,6 +205,13 @@ def video_summarize(
 
         save_dir = save_dir_path(video_request.url)
 
+        video_metadata = None
+        try:
+            video_metadata = get_video_metadata(video_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch video metadata for summarization: '{metadata_error}'")
+
         transcription = video_transcribe(
             video_request.url, save_dir, video_request.lang,
             WHISPER_RESPONSE_FORMAT.TEXT)
@@ -181,8 +226,9 @@ def video_summarize(
             transcription,
             ProcessArtifactFormat.TEXT, video_request.lang)
 
+        summary_input = build_video_summary_input(transcription, video_metadata)
         summarization = summarize(
-            transcription, video_request.type, video_request.lang)
+            summary_input, video_request.type, video_request.lang)
         register_process_artifact(
             current_user, process_id,
             ProcessArtifactType.SUMMARY,
@@ -199,7 +245,8 @@ def video_summarize(
         elif accept_header == "text/srt":
             return FileResponse(transcription, media_type="text/srt")
         else:
-            return SummaryResult(summary=summarization)
+            metadata_dict = video_metadata.model_dump(exclude={"subtitles"}) if video_metadata else None
+            return SummaryResult(summary=summarization, metadata=metadata_dict)
     except Exception as e:
         logging.error(f"Error processing video summarization: '{str(e)}'")
 

--- a/app/routers/video.py
+++ b/app/routers/video.py
@@ -117,6 +117,13 @@ def video_transcription(
             request_data={"video_request": video_request.model_dump()}
         )
 
+        video_metadata = None
+        try:
+            video_metadata = get_video_metadata(video_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch video metadata for transcription: '{metadata_error}'")
+
         save_dir = save_dir_path(video_request.url)
         transcription = video_transcribe(
             video_request.url,
@@ -137,10 +144,12 @@ def video_transcription(
         if accept_header == "text/plain":
             return PlainTextResponse(transcription)
         else:
+            metadata_dict = video_metadata.model_dump(exclude={"subtitles"}) if video_metadata else None
             return ApiProcessingResult(
                 result=True, error=None,
                 transcription=transcription,
-                format=video_request.response_format)
+                format=video_request.response_format,
+                metadata=metadata_dict)
     except Exception as e:
         logging.error(f"Error processing video transcription: {str(e)}")
 

--- a/app/routers/video.py
+++ b/app/routers/video.py
@@ -118,7 +118,7 @@ def video_transcription(
 
 @video_router.post(
     "/summarize",
-    response_model=SummaryResult,
+    response_model=SummaryResult | ApiProcessingResult,
     responses={
         200: {
             "description": "Summarization result. Content type depends on the `Accept` request header.",
@@ -170,6 +170,10 @@ def video_summarize(
         transcription = video_transcribe(
             video_request.url, save_dir, video_request.lang,
             WHISPER_RESPONSE_FORMAT.TEXT)
+
+        if not transcription.strip():
+            raise ValueError(
+                "No transcription generated from video audio. The source may have no detectable speech.")
 
         register_process_artifact(
             current_user, process_id,

--- a/app/routers/youtube.py
+++ b/app/routers/youtube.py
@@ -135,6 +135,44 @@ def save_dir_path(url):
     return save_dir
 
 
+def _trim_metadata_text(text: str, max_length: int = 2000) -> str:
+    cleaned_text = " ".join(text.split())
+    if len(cleaned_text) <= max_length:
+        return cleaned_text
+
+    return f"{cleaned_text[:max_length].rstrip()}..."
+
+
+def build_youtube_summary_input(
+        transcription: str,
+        metadata: YoutubeMetadata | None
+) -> str:
+    if not metadata:
+        return transcription
+
+    metadata_lines = []
+    if metadata.title:
+        metadata_lines.append(f"Title: {metadata.title}")
+    if metadata.duration_string:
+        metadata_lines.append(f"Duration: {metadata.duration_string}")
+    elif metadata.duration:
+        metadata_lines.append(f"Duration: {metadata.duration} seconds")
+    if metadata.description:
+        metadata_lines.append(
+            f"Description: {_trim_metadata_text(metadata.description)}")
+
+    if not metadata_lines:
+        return transcription
+
+    return "\n".join([
+        "Video metadata:",
+        *metadata_lines,
+        "",
+        "Transcript:",
+        transcription
+    ])
+
+
 @yt_router.post(
     "/summarize",
     response_model=SummaryResult,
@@ -200,6 +238,13 @@ def yt_summarize(
         )
 
         save_dir = save_dir_path(yt_request.url)
+        yt_metadata = None
+
+        try:
+            yt_metadata = get_youtube_metadata(yt_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch YouTube metadata for summarization: '{metadata_error}'")
 
         transcription = None
 
@@ -222,8 +267,10 @@ def yt_summarize(
             transcription,
             ProcessArtifactFormat.TEXT, yt_request.lang)
 
+        summary_input = build_youtube_summary_input(
+            transcription, yt_metadata)
         summarization = summarize(
-            transcription, yt_request.type, yt_request.lang)
+            summary_input, yt_request.type, yt_request.lang)
         register_process_artifact(
             current_user, process_id,
             ProcessArtifactType.SUMMARY,

--- a/app/routers/youtube.py
+++ b/app/routers/youtube.py
@@ -82,6 +82,13 @@ def yt_transcription(
                 "yt_request": yt_request.model_dump()}
         )
 
+        yt_metadata = None
+        try:
+            yt_metadata = get_youtube_metadata(yt_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch YouTube metadata for transcription: '{metadata_error}'")
+
         save_dir = save_dir_path(yt_request.url)
         transcription = yt_transcribe(
             yt_request.url,
@@ -105,7 +112,12 @@ def yt_transcription(
         if accept_header == "text/plain":
             return PlainTextResponse(transcription)
         else:
-            return ApiProcessingResult(result=True, error=None, transcription=transcription, format=yt_request.response_format)
+            metadata_dict = yt_metadata.model_dump(exclude={"subtitles"}) if yt_metadata else None
+            return ApiProcessingResult(
+                result=True, error=None,
+                transcription=transcription,
+                format=yt_request.response_format,
+                metadata=metadata_dict)
     except Exception as e:
         logging.error(f"Error processing YouTube transcription: {str(e)}")
 

--- a/app/routers/youtube.py
+++ b/app/routers/youtube.py
@@ -303,7 +303,8 @@ def yt_summarize(
             # return as a file
             return FileResponse(transcription, media_type="text/srt")
         else:
-            return SummaryResult(summary=summarization)
+            metadata_dict = yt_metadata.model_dump(exclude={"subtitles"}) if yt_metadata else None
+            return SummaryResult(summary=summarization, metadata=metadata_dict)
     except Exception as e:
         logging.error(f"Error processing YouTube summarization: '{str(e)}'")
 

--- a/app/schema/models.py
+++ b/app/schema/models.py
@@ -25,6 +25,7 @@ class RequestType(enum.Enum):
     TEXT = "text"
     FILE = "file"
     YOUTUBE = "youtube"
+    VIDEO = "video"
 
 class RequestStatus(enum.Enum):
     PENDING = "pending"

--- a/app/summary/summarization.py
+++ b/app/summary/summarization.py
@@ -23,7 +23,7 @@ def get_template(type):
 ## Output format (markdown)
 
 ### Summary
-Write as many detailed paragraphs as needed to cover all key ideas, arguments, and conclusions. Follow the chronological flow of the transcription — summarize segment by segment using the timestamps from the JSON chunks.
+Write as many detailed paragraphs as needed to cover all key ideas, arguments, and conclusions. If the input includes timestamps, follow the chronological flow and summarize segment by segment.
 
 ### Referenced media
 Articles, books, podcasts, movies, persons mentioned. For each item, add nested bullets with context of how/where it was mentioned. Omit this section if none found.
@@ -39,7 +39,8 @@ Software, hardware, services, products mentioned. For each, add nested bullets w
 
 ## Rules
 - Use markdown formatting: headers, bullet points, numbered lists, bold for key terms.
-- The transcription is in JSON format with timestamps and durations — use them to organize the summary chronologically.
+- The input may include video metadata followed by a transcript. Use metadata only as context; base the summary on the transcript.
+- When timestamps are present in [MM:SS] or [HH:MM:SS] format, use them to organize the summary chronologically.
 - Return only the summary, no meta-commentary.
 
 {text}"""

--- a/app/summary/summarization.py
+++ b/app/summary/summarization.py
@@ -18,33 +18,29 @@ def get_template(type):
         SUMMARIZATION_TYPE.TLDR:
             """Imagine you're a researcher who has only 30 seconds to summarize this article in language code={lang}. It should be based on the provided text and give 3 the most important details. \n{text}""",
         SUMMARIZATION_TYPE.DETAILED:
-            """As a professional summarizer, create a detailed, in-depth, and concise summary in language code={lang} of the provided text, while strongly adhering to these guidelines:
-- Incorporate main ideas and essential information, eliminating extraneous language and focusing on critical aspects.
-- Rely strictly on the provided text, without including external information.
-- Format the summary in paragraph form for easy understanding.
-- The entire content should be organized in a clear and logical manner
-- use markdown to format the text, you can use emojis, bullet points, numbered lists, etc. to make the summary more engaging and easy to read.
+            """You are a professional summarizer. Create a comprehensive summary in language code={lang} based strictly on the provided transcription. Do not add external information.
 
-Include extra information such as:
-- list of mentioned articles, books, podcasts,persons, movies etc. in seperated subsections.  Add in nested bullets details about context where,how item was mentioned. If empty, just skip it
-- list of guidelines, practises,techniques, rules, principles, steps, procedures etc. in seperated subsections. Add in nested bullets details about context where,how item was mentioned. If empty, just skip it
-- list of examples, scenarios, use cases, case studies etc. in seperated subsections.  Add in nested bullets details about context where,how item was mentioned. If empty, just skip it
-- list of tools, software, hardware, services, products etc. in seperated subsections. Add in nested bullets details about context where,how item was mentioned. If empty, just skip it
+## Output format (markdown)
 
-My needs:
-- I want to get super detailed summary of super important text. I use it for my academic research job and i need to get all the details from the text.
+### Summary
+Write as many detailed paragraphs as needed to cover all key ideas, arguments, and conclusions. Follow the chronological flow of the transcription — summarize segment by segment using the timestamps from the JSON chunks.
 
-I will pay you extra if you can provide me with a very detailed summary of the text. I need to get all the details from the text.
+### Referenced media
+Articles, books, podcasts, movies, persons mentioned. For each item, add nested bullets with context of how/where it was mentioned. Omit this section if none found.
 
-Take a deep breath and return very detailed summary in markdown of below  transcription and nothing else.
+### Guidelines & techniques
+Principles, rules, practices, steps, procedures mentioned. For each, add nested bullets with context. Omit if none found.
 
-In first sections with summarization - follow schema
-1. As many text paragraphs as required to very make very detailed summmary
-2. Summarizations minute after minute with details. You will get transcription in json chunks
+### Examples & case studies
+Scenarios, use cases, examples mentioned. For each, add nested bullets with context. Omit if none found.
 
-You receive transcription in JSON - with times, durations.
+### Tools & products
+Software, hardware, services, products mentioned. For each, add nested bullets with context. Omit if none found.
 
-Return only summarization, no comments.
+## Rules
+- Use markdown formatting: headers, bullet points, numbered lists, bold for key terms.
+- The transcription is in JSON format with timestamps and durations — use them to organize the summary chronologically.
+- Return only the summary, no meta-commentary.
 
 {text}"""
     }

--- a/app/video/loader.py
+++ b/app/video/loader.py
@@ -1,0 +1,79 @@
+import logging
+import random
+from typing import Iterable, List
+
+from langchain_community.document_loaders.blob_loaders import FileSystemBlobLoader
+from langchain_community.document_loaders.blob_loaders.schema import Blob, BlobLoader
+
+
+class VideoAudioLoader(BlobLoader):
+    """Load video URLs from any yt-dlp-supported platform as audio file(s)."""
+
+    def __init__(self, urls: List[str], save_dir: str, proxy_servers: List[str] = None):
+        if not isinstance(urls, list):
+            raise TypeError("urls must be a list")
+
+        self.urls = urls
+        self.save_dir = save_dir
+        self.proxy_servers = proxy_servers
+
+    def random_proxy(self):
+        return random.choice(self.proxy_servers)
+
+    def yield_blobs(self) -> Iterable[Blob]:
+        """Yield audio blobs for each url."""
+
+        try:
+            import yt_dlp
+        except ImportError:
+            raise ImportError(
+                "yt_dlp package not found, please install it with "
+                "`pip install yt_dlp`"
+            )
+
+        ydl_opts = {
+            "format": "m4a/bestaudio/best",
+            "noplaylist": True,
+            "outtmpl": self.save_dir + "/%(title)s.%(ext)s",
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "m4a",
+                }
+            ],
+            "verbose": True,
+        }
+
+        trial = 1
+        max_trials = 3
+
+        def contains_keywords(exception: Exception, keywords: list) -> bool:
+            return any(keyword in str(exception).lower() for keyword in keywords)
+
+        while trial < max_trials:
+            logging.debug(f"Download video {self.urls}, trial {trial}/{max_trials}")
+            if self.proxy_servers:
+                ydl_opts["proxy"] = self.random_proxy()
+
+            retcode = None
+            try:
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    retcode = ydl.download(self.urls)
+
+                break
+            except Exception as e:
+                logging.warning(
+                    f"Got exception: {e} code={retcode}, trying to download again (trial: {trial}/{max_trials})")
+
+                keywords = ["sign in", "login", "login_required", "bot", "429", "rate limit", "forbidden"]
+                if contains_keywords(e, keywords):
+                    trial += 1
+                    if trial == max_trials:
+                        raise e
+                else:
+                    logging.warning(f"Exception '{e}' does not contain retryable keywords, raising exception higher")
+                    raise e
+
+        loader = FileSystemBlobLoader(self.save_dir, glob="*.m4a")
+        for blob in loader.yield_blobs():
+            yield blob

--- a/app/video/metadata.py
+++ b/app/video/metadata.py
@@ -1,0 +1,73 @@
+import logging
+import random
+
+import yt_dlp
+
+from app.cache import conditional_lru_cache
+from app.models import VideoMetadata, YoutubeTranscriptionMetadata
+from app.settings import get_settings
+from app.youtube.proxy import proxy_servers
+
+
+@conditional_lru_cache
+def get_video_metadata(video_url: str) -> VideoMetadata:
+    info = extract_video_info(video_url)
+
+    video_all_subtitles = info.get('subtitles', {})
+    subtitles_metadata = {}
+    if video_all_subtitles:
+        for lang_code in video_all_subtitles:
+            sub_lang_versions = {}
+
+            for subtitle_version in video_all_subtitles[lang_code]:
+                if hasattr(subtitle_version, "name"):
+                    name = subtitle_version["name"]
+                else:
+                    name = subtitle_version.get("protocol", "N/A")
+
+                sub_lang_versions[subtitle_version["ext"]] = YoutubeTranscriptionMetadata(
+                    ext=subtitle_version["ext"],
+                    url=subtitle_version["url"],
+                    name=name
+                )
+
+            subtitles_metadata[lang_code] = sub_lang_versions
+
+    metadata = VideoMetadata(
+        title=info.get('title', ''),
+        full_title=info.get('fulltitle', None),
+        description=info.get('description', ''),
+        duration=info.get('duration'),
+        duration_string=info.get('duration_string'),
+        uploader=info.get('uploader', None),
+        uploader_url=info.get('uploader_url', None) or info.get('channel_url', None),
+        platform=info.get('extractor_key', None) or info.get('extractor', None),
+        original_url=info.get('original_url', video_url),
+        upload_date=info.get('upload_date'),
+        thumbnail=info.get('thumbnail', None),
+        language=info.get('language', None),
+        subtitles=subtitles_metadata,
+        available_transcriptions=list(subtitles_metadata.keys()),
+    )
+
+    return metadata
+
+
+def extract_video_info(video_url: str):
+    logging.info(f"Extracting video info for {video_url}...")
+
+    ydl_opts = {
+        'skip_download': True,
+        'quiet': True,
+    }
+
+    proxys = proxy_servers()
+    if get_settings().use_proxy and proxys:
+        proxy = random.choice(proxys)
+        ydl_opts["proxy"] = proxy
+        logging.debug(f"Using '{proxy}' to get video details.")
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(video_url, download=False)
+
+    return info

--- a/app/video/transcription.py
+++ b/app/video/transcription.py
@@ -1,0 +1,43 @@
+import logging
+
+import langsmith as ls
+from langchain_community.document_loaders.generic import GenericLoader
+
+from app.cache import conditional_lru_cache
+from app.settings import get_settings
+from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT, convert_response_format
+from app.transcribe.OpenAIWhisperParser import OpenAIWhisperParser
+from app.video.loader import VideoAudioLoader
+
+
+@ls.traceable(
+    run_type="llm",
+    name="Video Transcription",
+    tags=["video", "transcription"],
+    metadata={"flow": "transcription"}
+)
+@conditional_lru_cache
+def video_transcribe(url: str,
+                     save_dir: str,
+                     lang: LANG_CODE,
+                     response_format: WHISPER_RESPONSE_FORMAT):
+    logging.info(
+        f"Processing video url: {url}, save_dir: {save_dir}, lang: {lang}, response_format: {response_format}")
+
+    settings = get_settings()
+    proxy_servers = settings.proxy_servers.split(
+        ",") if settings.proxy_servers and settings.use_proxy else None
+
+    logging.debug(
+        f"Proxy servers: {proxy_servers} - using proxy: {settings.use_proxy}")
+
+    loader = GenericLoader(VideoAudioLoader([url], save_dir, proxy_servers),
+                           OpenAIWhisperParser(api_key=settings.openai_api_key,
+                                               language=lang.value,
+                                               response_format=convert_response_format(
+                                                   response_format),
+                                               temperature=0
+                                               ))
+    docs = loader.load()
+
+    return " ".join([doc.page_content for doc in docs])

--- a/app/youtube/transcriptions.py
+++ b/app/youtube/transcriptions.py
@@ -1,8 +1,61 @@
-
 import logging
+import re
+from html import unescape
+
 from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT
 from app.utils.internet import download_file
 from app.youtube.metadata import get_youtube_metadata
+
+
+def _format_vtt_timestamp(timestamp: str) -> str:
+    time_part = timestamp.split(".", 1)[0]
+    parts = time_part.split(":")
+
+    if len(parts) == 3 and parts[0] == "00":
+        return f"{parts[1]}:{parts[2]}"
+
+    return time_part
+
+
+def _clean_vtt_text(text: str) -> str:
+    without_tags = re.sub(r"<[^>]+>", "", text)
+    return " ".join(unescape(without_tags).split())
+
+
+def normalize_vtt_transcription(raw_vtt: str) -> str:
+    segments = []
+    current_start = None
+    current_text_lines = []
+
+    for line in raw_vtt.splitlines():
+        stripped = line.strip()
+
+        if not stripped:
+            if current_start and current_text_lines:
+                text = _clean_vtt_text(" ".join(current_text_lines))
+                if text:
+                    segments.append(f"[{current_start}] {text}")
+            current_start = None
+            current_text_lines = []
+            continue
+
+        if stripped == "WEBVTT" or stripped.startswith(("Kind:", "Language:", "NOTE", "STYLE", "REGION")):
+            continue
+
+        if "-->" in stripped:
+            current_start = _format_vtt_timestamp(stripped.split("-->", 1)[0].strip())
+            current_text_lines = []
+            continue
+
+        if current_start:
+            current_text_lines.append(stripped)
+
+    if current_start and current_text_lines:
+        text = _clean_vtt_text(" ".join(current_text_lines))
+        if text:
+            segments.append(f"[{current_start}] {text}")
+
+    return "\n".join(segments)
 
 
 def download_transcription(url: str, lang: LANG_CODE, save_dir: str):
@@ -23,8 +76,9 @@ def download_transcription(url: str, lang: LANG_CODE, save_dir: str):
             logging.info(
                 f"Downloading YT transcription: '{subtitle_url}' for language '{lang}' and video '{url}'")
             transcription_file = download_file(subtitle_url, save_dir)
-            # read transcription file and convert to text
-            transcription = open(transcription_file, "r").read()
+            with open(transcription_file, "r", encoding="utf-8") as file:
+                raw_transcription = file.read()
+            transcription = normalize_vtt_transcription(raw_transcription)
             logging.debug(
                 f"Downloaded transcription to file {transcription_file}")
             return transcription

--- a/docs/superpowers/plans/2026-06-20-generic-video-processing.md
+++ b/docs/superpowers/plans/2026-06-20-generic-video-processing.md
@@ -1,0 +1,1322 @@
+# Generic Video Processing Endpoints (Vimeo, Instagram, etc.)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/video` endpoint group that processes URLs from any yt-dlp-supported platform (Vimeo, Instagram, TikTok, Dailymotion, etc.) with the same transcription, summarization, logging, and artifact-saving logic already used for YouTube and audio.
+
+**Architecture:** A new `app/video/` module mirrors `app/youtube/` with a generic `VideoAudioLoader` (yt-dlp without YouTube-specific options) and a `get_video_metadata()` function. A new `app/routers/video.py` router exposes `/video/transcribe`, `/video/summarize`, and `/video/details` endpoints. The existing `transcribe()`, `summarize()`, `register_new_process()`, `register_process_artifact()` infrastructure is reused as-is.
+
+**Tech Stack:** FastAPI, yt-dlp, Pydantic v2, SQLAlchemy, OpenAI Whisper API, LangChain, Alembic
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `app/video/__init__.py` | Package marker |
+| Create | `app/video/loader.py` | `VideoAudioLoader` – yt-dlp download for generic URLs |
+| Create | `app/video/metadata.py` | `get_video_metadata()` – extract metadata via yt-dlp |
+| Create | `app/routers/video.py` | FastAPI router: `/video/transcribe`, `/video/summarize`, `/video/details` |
+| Modify | `app/models.py` | Add `VideoTranscribe`, `VideoSummarize`, `VideoInfoRequest`, `VideoMetadata` Pydantic models |
+| Modify | `app/schema/models.py` | Add `RequestType.VIDEO` enum value |
+| Modify | `app/processing/processing.py` | Handle `RequestType.VIDEO` in `register_new_process()` |
+| Modify | `app/main.py` | Register `video_router` |
+| Create | `alembic/versions/add_video_request_type.py` | DB migration for `RequestType.VIDEO` |
+| Create | `tests/test_video.py` | Unit tests for video endpoints |
+
+---
+
+### Task 1: Add `RequestType.VIDEO` to schema enums
+
+**Files:**
+- Modify: `app/schema/models.py:23-27`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py
+from app.schema.models import RequestType
+
+
+def test_video_request_type_exists():
+    assert RequestType.VIDEO.value == "video"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_video.py::test_video_request_type_exists -v`
+Expected: FAIL with `AttributeError: 'VIDEO' is not a member of 'RequestType'`
+
+- [ ] **Step 3: Add VIDEO to RequestType enum**
+
+In `app/schema/models.py`, change:
+
+```python
+class RequestType(enum.Enum):
+    AUDIO = "audio"
+    TEXT = "text"
+    FILE = "file"
+    YOUTUBE = "youtube"
+```
+
+to:
+
+```python
+class RequestType(enum.Enum):
+    AUDIO = "audio"
+    TEXT = "text"
+    FILE = "file"
+    YOUTUBE = "youtube"
+    VIDEO = "video"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_video.py::test_video_request_type_exists -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schema/models.py tests/test_video.py
+git commit -m "feat: add VIDEO request type to schema enums"
+```
+
+---
+
+### Task 2: Handle `RequestType.VIDEO` in processing module
+
+**Files:**
+- Modify: `app/processing/processing.py:17-26`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+from unittest.mock import patch, MagicMock
+from app.processing.processing import register_new_process
+from app.schema.models import RequestType, UserProcessSourceType
+
+
+def test_register_new_process_video_type():
+    mock_user = MagicMock()
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
+
+    mock_request = MagicMock()
+    mock_request.url = "http://test"
+    mock_request.method = "POST"
+
+    mock_db = MagicMock()
+    mock_process = MagicMock()
+    mock_process.id = "00000000-0000-0000-0000-000000000002"
+    mock_db.return_value = mock_db
+    mock_db.add = MagicMock()
+    mock_db.commit = MagicMock()
+    mock_db.refresh = MagicMock(side_effect=lambda p: setattr(p, 'id', mock_process.id))
+    mock_db.close = MagicMock()
+
+    with patch('app.processing.processing.get_session_maker', return_value=lambda: mock_db):
+        result = register_new_process(
+            mock_user,
+            RequestType.VIDEO,
+            request=mock_request,
+            request_data={"url": "https://vimeo.com/123"}
+        )
+
+    call_args = mock_db.add.call_args[0][0]
+    assert call_args.source_type == UserProcessSourceType.URL
+    assert call_args.type == RequestType.VIDEO
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_video.py::test_register_new_process_video_type -v`
+Expected: FAIL with `ValueError: Invalid request type: RequestType.VIDEO`
+
+- [ ] **Step 3: Add VIDEO case to register_new_process**
+
+In `app/processing/processing.py`, change the match statement:
+
+```python
+        match(request_type):
+            case RequestType.AUDIO:
+                source_type = UserProcessSourceType.FILE
+            case RequestType.TEXT:
+                source_type = UserProcessSourceType.URL
+            case RequestType.YOUTUBE:
+                source_type = UserProcessSourceType.URL
+            case _:
+                raise ValueError(f"Invalid request type: {request_type}")
+```
+
+to:
+
+```python
+        match(request_type):
+            case RequestType.AUDIO:
+                source_type = UserProcessSourceType.FILE
+            case RequestType.TEXT:
+                source_type = UserProcessSourceType.URL
+            case RequestType.YOUTUBE:
+                source_type = UserProcessSourceType.URL
+            case RequestType.VIDEO:
+                source_type = UserProcessSourceType.URL
+            case _:
+                raise ValueError(f"Invalid request type: {request_type}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_video.py::test_register_new_process_video_type -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/processing/processing.py tests/test_video.py
+git commit -m "feat: handle VIDEO request type in process registration"
+```
+
+---
+
+### Task 3: Create `VideoAudioLoader`
+
+**Files:**
+- Create: `app/video/__init__.py`
+- Create: `app/video/loader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+from unittest.mock import patch, MagicMock
+from app.video.loader import VideoAudioLoader
+
+
+def test_video_audio_loader_init():
+    loader = VideoAudioLoader(["https://vimeo.com/123456"], "/tmp/test_save")
+    assert loader.urls == ["https://vimeo.com/123456"]
+    assert loader.save_dir == "/tmp/test_save"
+    assert loader.proxy_servers is None
+
+
+def test_video_audio_loader_init_with_proxy():
+    loader = VideoAudioLoader(
+        ["https://vimeo.com/123456"],
+        "/tmp/test_save",
+        proxy_servers=["http://proxy1:8080"]
+    )
+    assert loader.proxy_servers == ["http://proxy1:8080"]
+
+
+def test_video_audio_loader_urls_must_be_list():
+    try:
+        VideoAudioLoader("https://vimeo.com/123456", "/tmp/test_save")
+        assert False, "Should have raised TypeError"
+    except TypeError:
+        pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_video.py::test_video_audio_loader_init -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.video'`
+
+- [ ] **Step 3: Create the video package and loader**
+
+Create `app/video/__init__.py` (empty file).
+
+Create `app/video/loader.py`:
+
+```python
+import logging
+import random
+from typing import Iterable, List
+
+from langchain_community.document_loaders.blob_loaders import FileSystemBlobLoader
+from langchain_community.document_loaders.blob_loaders.schema import Blob, BlobLoader
+
+
+class VideoAudioLoader(BlobLoader):
+    """Load video URLs from any yt-dlp-supported platform as audio file(s)."""
+
+    def __init__(self, urls: List[str], save_dir: str, proxy_servers: List[str] = None):
+        if not isinstance(urls, list):
+            raise TypeError("urls must be a list")
+
+        self.urls = urls
+        self.save_dir = save_dir
+        self.proxy_servers = proxy_servers
+
+    def random_proxy(self):
+        return random.choice(self.proxy_servers)
+
+    def yield_blobs(self) -> Iterable[Blob]:
+        """Yield audio blobs for each url."""
+
+        try:
+            import yt_dlp
+        except ImportError:
+            raise ImportError(
+                "yt_dlp package not found, please install it with "
+                "`pip install yt_dlp`"
+            )
+
+        ydl_opts = {
+            "format": "m4a/bestaudio/best",
+            "noplaylist": True,
+            "outtmpl": self.save_dir + "/%(title)s.%(ext)s",
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "m4a",
+                }
+            ],
+            "verbose": True,
+        }
+
+        trial = 1
+        max_trials = 3
+
+        def contains_keywords(exception: Exception, keywords: list) -> bool:
+            return any(keyword in str(exception).lower() for keyword in keywords)
+
+        while trial < max_trials:
+            logging.debug(f"Download video {self.urls}, trial {trial}/{max_trials}")
+            if self.proxy_servers:
+                ydl_opts["proxy"] = self.random_proxy()
+
+            retcode = None
+            try:
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    retcode = ydl.download(self.urls)
+
+                break
+            except Exception as e:
+                logging.warning(
+                    f"Got exception: {e} code={retcode}, trying to download again (trial: {trial}/{max_trials})")
+
+                keywords = ["sign in", "login", "login_required", "bot", "429", "rate limit", "forbidden"]
+                if contains_keywords(e, keywords):
+                    trial += 1
+                    if trial == max_trials:
+                        raise e
+                else:
+                    logging.warning(f"Exception '{e}' does not contain retryable keywords, raising exception higher")
+                    raise e
+
+        loader = FileSystemBlobLoader(self.save_dir, glob="*.m4a")
+        for blob in loader.yield_blobs():
+            yield blob
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_video.py::test_video_audio_loader_init tests/test_video.py::test_video_audio_loader_init_with_proxy tests/test_video.py::test_video_audio_loader_urls_must_be_list -v`
+Expected: PASS (all 3)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/video/__init__.py app/video/loader.py tests/test_video.py
+git commit -m "feat: add VideoAudioLoader for generic yt-dlp video download"
+```
+
+---
+
+### Task 4: Create video metadata extraction
+
+**Files:**
+- Create: `app/video/metadata.py`
+- Modify: `app/models.py` (add `VideoMetadata` model)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+from app.models import VideoMetadata
+
+
+def test_video_metadata_model():
+    metadata = VideoMetadata(
+        title="Test Video",
+        description="A test video",
+        duration=120.5,
+        duration_string="2:00",
+        platform="vimeo",
+        original_url="https://vimeo.com/123456",
+    )
+    assert metadata.title == "Test Video"
+    assert metadata.platform == "vimeo"
+    assert metadata.duration == 120.5
+    assert metadata.thumbnail is None
+    assert metadata.uploader is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_video.py::test_video_metadata_model -v`
+Expected: FAIL with `ImportError: cannot import name 'VideoMetadata' from 'app.models'`
+
+- [ ] **Step 3: Add VideoMetadata model to app/models.py**
+
+Append to `app/models.py`:
+
+```python
+class VideoMetadata(BaseModel):
+    title: str = Field(
+        default="", description="The title of the video")
+    full_title: Optional[str] = Field(None,
+        description="The full title of the video")
+    description: str = Field(
+        default="", description="The description of the video")
+    duration: Optional[float] = Field(
+        None, description="The duration of the video in seconds")
+    duration_string: Optional[str] = Field(None,
+        description="A human-readable string representation of the video duration")
+    uploader: Optional[str] = Field(
+        None, description="Name of the uploader/channel")
+    uploader_url: Optional[str] = Field(
+        None, description="URL of the uploader/channel page")
+    platform: Optional[str] = Field(
+        None, description="Name of the platform (e.g. vimeo, instagram)")
+    original_url: Optional[str] = Field(
+        None, description="The original URL of the video")
+    upload_date: Optional[datetime] = Field(
+        None, description="The date when the video was uploaded")
+    thumbnail: Optional[str] = Field(
+        None, description="The URL of the video thumbnail image")
+    language: Optional[str] = Field(
+        None, description="The primary language of the video content")
+    subtitles: dict[str, dict[str, YoutubeTranscriptionMetadata]] = Field(
+        default_factory=dict,
+        description="Available subtitles organized by language and format")
+    available_transcriptions: List[str] = Field(
+        default_factory=list,
+        description="List of available transcription languages")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_video.py::test_video_metadata_model -v`
+Expected: PASS
+
+- [ ] **Step 5: Create `app/video/metadata.py`**
+
+```python
+import logging
+import random
+
+import yt_dlp
+
+from app.cache import conditional_lru_cache
+from app.models import VideoMetadata, YoutubeTranscriptionMetadata
+from app.settings import get_settings
+from app.youtube.proxy import proxy_servers
+
+
+@conditional_lru_cache
+def get_video_metadata(video_url: str) -> VideoMetadata:
+    info = extract_video_info(video_url)
+
+    video_all_subtitles = info.get('subtitles', {})
+    subtitles_metadata = {}
+    if video_all_subtitles:
+        for lang_code in video_all_subtitles:
+            sub_lang_versions = {}
+
+            for subtitle_version in video_all_subtitles[lang_code]:
+                name = ""
+                if hasattr(subtitle_version, "name"):
+                    name = subtitle_version["name"]
+                else:
+                    name = subtitle_version.get("protocol", "N/A")
+
+                sub_lang_versions[subtitle_version["ext"]] = YoutubeTranscriptionMetadata(
+                    ext=subtitle_version["ext"],
+                    url=subtitle_version["url"],
+                    name=name
+                )
+
+            subtitles_metadata[lang_code] = sub_lang_versions
+
+    metadata = VideoMetadata(
+        title=info.get('title', ''),
+        full_title=info.get('fulltitle', None),
+        description=info.get('description', ''),
+        duration=info.get('duration'),
+        duration_string=info.get('duration_string'),
+        uploader=info.get('uploader', None),
+        uploader_url=info.get('uploader_url', None) or info.get('channel_url', None),
+        platform=info.get('extractor_key', None) or info.get('extractor', None),
+        original_url=info.get('original_url', video_url),
+        upload_date=info.get('upload_date'),
+        thumbnail=info.get('thumbnail', None),
+        language=info.get('language', None),
+        subtitles=subtitles_metadata,
+        available_transcriptions=list(subtitles_metadata.keys()),
+    )
+
+    return metadata
+
+
+def extract_video_info(video_url: str):
+    logging.info(f"Extracting video info for {video_url}...")
+
+    ydl_opts = {
+        'skip_download': True,
+        'quiet': True,
+    }
+
+    proxys = proxy_servers()
+    if get_settings().use_proxy and proxys:
+        proxy = random.choice(proxys)
+        ydl_opts["proxy"] = proxy
+        logging.debug(f"Using '{proxy}' to get video details.")
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(video_url, download=False)
+
+    return info
+```
+
+- [ ] **Step 6: Run all video tests**
+
+Run: `pytest tests/test_video.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/models.py app/video/metadata.py tests/test_video.py
+git commit -m "feat: add VideoMetadata model and metadata extraction"
+```
+
+---
+
+### Task 5: Add Pydantic request models for video endpoints
+
+**Files:**
+- Modify: `app/models.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+from app.models import VideoTranscribe, VideoSummarize, VideoInfoRequest
+from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT
+from app.models import SUMMARIZATION_TYPE
+
+
+def test_video_transcribe_model_defaults():
+    req = VideoTranscribe(url="https://vimeo.com/123456")
+    assert req.url == "https://vimeo.com/123456"
+    assert req.lang == LANG_CODE.POLISH
+    assert req.response_format == WHISPER_RESPONSE_FORMAT.SRT
+
+
+def test_video_summarize_model_defaults():
+    req = VideoSummarize(url="https://vimeo.com/123456")
+    assert req.url == "https://vimeo.com/123456"
+    assert req.type == SUMMARIZATION_TYPE.TLDR
+    assert req.lang == LANG_CODE.POLISH
+
+
+def test_video_info_request_model():
+    req = VideoInfoRequest(url="https://www.instagram.com/reel/abc123")
+    assert req.url == "https://www.instagram.com/reel/abc123"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_video.py::test_video_transcribe_model_defaults tests/test_video.py::test_video_summarize_model_defaults tests/test_video.py::test_video_info_request_model -v`
+Expected: FAIL with `ImportError: cannot import name 'VideoTranscribe' from 'app.models'`
+
+- [ ] **Step 3: Add video request models to app/models.py**
+
+Append to `app/models.py`:
+
+```python
+class VideoTranscribe(BaseModel):
+    url: str
+    lang: LANG_CODE = Field(default=LANG_CODE.POLISH,
+                            title="Video language as ISO-639-1 code like PL, EN")
+    response_format: WHISPER_RESPONSE_FORMAT = Field(
+        default=WHISPER_RESPONSE_FORMAT.SRT, title="Response format")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789",
+                    "lang": "en",
+                    "response_format": "srt"
+                }
+            ]
+        }
+    }
+
+
+class VideoSummarize(BaseModel):
+    url: str
+    type: SUMMARIZATION_TYPE = Field(
+        default=SUMMARIZATION_TYPE.TLDR, title="Type of summarization")
+    lang: LANG_CODE = Field(default=LANG_CODE.POLISH,
+                            title="Language code of transcription and final summarization text")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789",
+                    "type": "detailed",
+                    "lang": "en"
+                }
+            ]
+        }
+    }
+
+
+class VideoInfoRequest(BaseModel):
+    url: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "url": "https://vimeo.com/123456789"
+                }
+            ]
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_video.py::test_video_transcribe_model_defaults tests/test_video.py::test_video_summarize_model_defaults tests/test_video.py::test_video_info_request_model -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models.py tests/test_video.py
+git commit -m "feat: add Pydantic request models for video endpoints"
+```
+
+---
+
+### Task 6: Create video transcription function
+
+**Files:**
+- Create: `app/video/transcription.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+from unittest.mock import patch, MagicMock
+from app.video.transcription import video_transcribe
+from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT
+
+
+@patch('app.video.transcription.GenericLoader')
+@patch('app.video.transcription.get_settings')
+def test_video_transcribe_returns_text(mock_settings, mock_generic_loader):
+    mock_settings_obj = MagicMock()
+    mock_settings_obj.openai_api_key = "test-key"
+    mock_settings_obj.proxy_servers = ""
+    mock_settings_obj.use_proxy = False
+    mock_settings.return_value = mock_settings_obj
+
+    mock_doc = MagicMock()
+    mock_doc.page_content = "Hello, this is a test transcription."
+    mock_generic_loader.return_value.load.return_value = [mock_doc]
+
+    result = video_transcribe(
+        "https://vimeo.com/123",
+        "/tmp/test",
+        LANG_CODE.ENGLISH,
+        WHISPER_RESPONSE_FORMAT.TEXT
+    )
+
+    assert result == "Hello, this is a test transcription."
+    mock_generic_loader.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_video.py::test_video_transcribe_returns_text -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.video.transcription'`
+
+- [ ] **Step 3: Create `app/video/transcription.py`**
+
+```python
+import logging
+
+import langsmith as ls
+from langchain_community.document_loaders.generic import GenericLoader
+
+from app.cache import conditional_lru_cache
+from app.settings import get_settings
+from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT, convert_response_format
+from app.transcribe.OpenAIWhisperParser import OpenAIWhisperParser
+from app.video.loader import VideoAudioLoader
+
+
+@ls.traceable(
+    run_type="llm",
+    name="Video Transcription",
+    tags=["video", "transcription"],
+    metadata={"flow": "transcription"}
+)
+@conditional_lru_cache
+def video_transcribe(url: str,
+                     save_dir: str,
+                     lang: LANG_CODE,
+                     response_format: WHISPER_RESPONSE_FORMAT):
+    logging.info(
+        f"Processing video url: {url}, save_dir: {save_dir}, lang: {lang}, response_format: {response_format}")
+
+    settings = get_settings()
+    proxy_servers = settings.proxy_servers.split(
+        ",") if settings.proxy_servers and settings.use_proxy else None
+
+    logging.debug(
+        f"Proxy servers: {proxy_servers} - using proxy: {settings.use_proxy}")
+
+    loader = GenericLoader(VideoAudioLoader([url], save_dir, proxy_servers),
+                           OpenAIWhisperParser(api_key=settings.openai_api_key,
+                                               language=lang.value,
+                                               response_format=convert_response_format(
+                                                   response_format),
+                                               temperature=0
+                                               ))
+    docs = loader.load()
+
+    return " ".join([doc.page_content for doc in docs])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_video.py::test_video_transcribe_returns_text -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/video/transcription.py tests/test_video.py
+git commit -m "feat: add video_transcribe function for generic video URLs"
+```
+
+---
+
+### Task 7: Create video router
+
+**Files:**
+- Create: `app/routers/video.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+import importlib
+
+
+def test_video_router_module_loads():
+    mod = importlib.import_module("app.routers.video")
+    assert hasattr(mod, "video_router")
+
+
+def test_video_router_has_transcribe_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/transcribe" in paths
+
+
+def test_video_router_has_summarize_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/summarize" in paths
+
+
+def test_video_router_has_details_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/details" in paths
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_video.py::test_video_router_module_loads -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `app/routers/video.py`**
+
+```python
+import hashlib
+import logging
+
+from fastapi import APIRouter, Request, Depends, Response, status
+from fastapi.responses import FileResponse
+from starlette.responses import PlainTextResponse
+
+from app.auth import get_current_active_user
+from app.models import (
+    VideoTranscribe, VideoSummarize, VideoInfoRequest,
+    VideoMetadata, SummaryResult, ApiProcessingResult,
+)
+from app.processing.processing import (
+    complete_process, process_failed, register_new_process,
+    register_process_artifact, update_process_status,
+)
+from app.schema.models import ProcessArtifactFormat, ProcessArtifactType, RequestStatus, RequestType
+from app.schema.pydantic_models import CompletedProcess, User
+from app.summary.summarization import summarize
+from app.transcribe.transcription import WHISPER_RESPONSE_FORMAT
+from app.video.metadata import get_video_metadata
+from app.video.transcription import video_transcribe
+
+video_router = APIRouter(
+    prefix="/video",
+    tags=["video", "transcription", "summarization"],
+    dependencies=[Depends(get_current_active_user)]
+)
+
+
+def save_dir_path(url: str) -> str:
+    hash_object = hashlib.md5(url.encode())
+    hash_hex = hash_object.hexdigest()
+    return f"./downloads/video/{hash_hex}/"
+
+
+@video_router.post(
+    "/transcribe",
+    response_model=ApiProcessingResult,
+    responses={
+        200: {
+            "description": "Transcription result. Content type depends on the `Accept` request header.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": True, "error": None, "transcription": "Hello world", "format": "srt"},
+                },
+                "text/plain": {
+                    "schema": {"type": "string"},
+                    "example": "Hello world",
+                },
+            },
+        },
+        500: {
+            "description": "Internal server error during transcription.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Internal server error: <details>", "text": None},
+                }
+            },
+        },
+    },
+)
+def video_transcription(
+        request: Request,
+        video_request: VideoTranscribe,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video transcribe - request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            request_type=RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        save_dir = save_dir_path(video_request.url)
+        transcription = video_transcribe(
+            video_request.url,
+            save_dir,
+            video_request.lang,
+            video_request.response_format)
+
+        update_process_status(process_id, CompletedProcess(
+            user_id=current_user.id,
+            status=RequestStatus.COMPLETED,
+            result=transcription,
+            result_format=ProcessArtifactFormat.TEXT,
+            lang=video_request.lang,
+            type=ProcessArtifactType.TRANSCRIPTION
+        ))
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(transcription)
+        else:
+            return ApiProcessingResult(
+                result=True, error=None,
+                transcription=transcription,
+                format=video_request.response_format)
+    except Exception as e:
+        logging.error(f"Error processing video transcription: {str(e)}")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Internal server error: {str(e)}",
+        )
+
+
+@video_router.post(
+    "/summarize",
+    response_model=SummaryResult,
+    responses={
+        200: {
+            "description": "Summarization result. Content type depends on the `Accept` request header.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/SummaryResult"},
+                    "example": {"summary": "The video covers the main highlights..."},
+                },
+                "text/plain": {
+                    "schema": {"type": "string"},
+                    "example": "The video covers the main highlights...",
+                },
+                "text/srt": {
+                    "schema": {"type": "string", "format": "binary"},
+                    "example": "1\n00:00:01,000 --> 00:00:05,000\nHello world",
+                },
+            },
+        },
+        500: {
+            "description": "Internal server error during transcription or summarization.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Error processing video summarization", "text": "<details>"},
+                }
+            },
+        },
+    },
+)
+def video_summarize(
+        request: Request,
+        video_request: VideoSummarize,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video summarize - Request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        save_dir = save_dir_path(video_request.url)
+
+        transcription = video_transcribe(
+            video_request.url, save_dir, video_request.lang,
+            WHISPER_RESPONSE_FORMAT.TEXT)
+
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.TRANSCRIPTION,
+            transcription,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        summarization = summarize(
+            transcription, video_request.type, video_request.lang)
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.SUMMARY,
+            summarization,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        logging.debug(f"video summarize - Result: \n{summarization}")
+
+        complete_process(process_id)
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(summarization)
+        elif accept_header == "text/srt":
+            return FileResponse(transcription, media_type="text/srt")
+        else:
+            return SummaryResult(summary=summarization)
+    except Exception as e:
+        logging.error(f"Error processing video summarization: '{str(e)}'")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error="Error processing video summarization",
+            text=str(e))
+
+
+@video_router.post(
+    "/details",
+    response_model=VideoMetadata | ApiProcessingResult,
+    responses={
+        200: {
+            "description": "Video metadata.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/VideoMetadata"},
+                    "example": {
+                        "title": "Example Video",
+                        "duration": 120.0,
+                        "duration_string": "2:00",
+                        "description": "Video description here.",
+                        "platform": "Vimeo",
+                        "uploader": "Example User",
+                    },
+                }
+            },
+        },
+        500: {
+            "description": "Internal server error while fetching video metadata.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ApiProcessingResult"},
+                    "example": {"result": False, "error": "Error extracting video details: <details>", "text": "<details>"},
+                }
+            },
+        },
+    },
+)
+def video_details(
+        request: VideoInfoRequest,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    try:
+        logging.info(f"Getting video details: {request.url}")
+
+        metadata = get_video_metadata(request.url)
+
+        return metadata
+    except Exception as e:
+        logging.error(f"Error fetching video details: {str(e)}")
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Error extracting video details: {str(e)}",
+            text=str(e))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_video.py::test_video_router_module_loads tests/test_video.py::test_video_router_has_transcribe_endpoint tests/test_video.py::test_video_router_has_summarize_endpoint tests/test_video.py::test_video_router_has_details_endpoint -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/video.py tests/test_video.py
+git commit -m "feat: add video router with transcribe, summarize, and details endpoints"
+```
+
+---
+
+### Task 8: Register video router in main.py
+
+**Files:**
+- Modify: `app/main.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_video.py  (append to existing file)
+
+def test_video_router_prefix():
+    from app.routers.video import video_router
+    assert video_router.prefix == "/video"
+    assert "video" in video_router.tags
+```
+
+- [ ] **Step 2: Add video router imports and registration to main.py**
+
+In `app/main.py`, add the import after the existing router imports:
+
+```python
+from app.routers.video import video_router
+```
+
+Add the router to the protected app (after `protected_app.include_router(artifacts_router)`):
+
+```python
+protected_app.include_router(video_router)
+```
+
+Add the router to the main app (after `app.include_router(artifacts_router)`):
+
+```python
+app.include_router(video_router)
+```
+
+The full relevant section of `app/main.py` after changes:
+
+```python
+from app.routers.audio import a_router
+from app.routers.auth import auth_router
+from app.routers.youtube import yt_router
+from app.routers.artifacts import router as artifacts_router
+from app.routers.video import video_router
+
+# ... (existing code) ...
+
+# Include routers in the protected app
+protected_app.include_router(a_router)
+protected_app.include_router(yt_router)
+protected_app.include_router(artifacts_router)
+protected_app.include_router(artifacts_router)
+protected_app.include_router(video_router)
+
+# Include the protected app and auth router in the main app
+app.mount("/api", protected_app)
+app.include_router(auth_router)
+app.include_router(yt_router)
+app.include_router(a_router)
+app.include_router(artifacts_router)
+app.include_router(video_router)
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `pytest tests/test_video.py::test_video_router_prefix -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/main.py tests/test_video.py
+git commit -m "feat: register video router in main app"
+```
+
+---
+
+### Task 9: Create Alembic migration for VIDEO request type
+
+**Files:**
+- Create: `alembic/versions/add_video_request_type.py`
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `cd /Users/michmzr/1.Projects/transition-summarize-py && alembic revision --autogenerate -m "add_video_request_type"`
+
+- [ ] **Step 2: Edit the generated migration file**
+
+Replace the auto-generated `upgrade()` and `downgrade()` functions with:
+
+```python
+from alembic import op
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE requesttype ADD VALUE IF NOT EXISTS 'video'")
+
+
+def downgrade() -> None:
+    pass
+```
+
+Note: PostgreSQL does not support removing values from enum types, so downgrade is a no-op. This is standard practice.
+
+- [ ] **Step 3: Verify migration syntax**
+
+Run: `cd /Users/michmzr/1.Projects/transition-summarize-py && python -c "import importlib; m = importlib.import_module('alembic.versions'); print('OK')"`
+
+This just checks the file is importable without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/*add_video_request_type*.py
+git commit -m "migration: add 'video' value to requesttype enum"
+```
+
+---
+
+### Task 10: Integration-style tests for video router
+
+**Files:**
+- Modify: `tests/test_video.py`
+
+- [ ] **Step 1: Add integration-level tests with mocked dependencies**
+
+```python
+# tests/test_video.py  (append to existing file)
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from app.routers.video import video_router
+
+
+def _create_test_app():
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    return test_app
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.update_process_status')
+def test_video_transcribe_endpoint_success(
+    mock_update, mock_transcribe, mock_register, mock_auth
+):
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.return_value = "Transcribed text from Vimeo video."
+
+    app = _create_test_app()
+    app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={"url": "https://vimeo.com/123456", "lang": "en", "response_format": "text"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["result"] is True
+    assert data["transcription"] == "Transcribed text from Vimeo video."
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_endpoint_success(
+    mock_complete, mock_summarize, mock_artifact,
+    mock_transcribe, mock_register, mock_auth
+):
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.return_value = "Transcribed text."
+    mock_summarize.return_value = "This is a summary of the video."
+
+    app = _create_test_app()
+    app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://vimeo.com/123456", "type": "tldr", "lang": "en"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"] == "This is a summary of the video."
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.get_video_metadata')
+def test_video_details_endpoint_success(mock_metadata, mock_auth):
+    from app.models import VideoMetadata
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_metadata.return_value = VideoMetadata(
+        title="Vimeo Video",
+        description="A cool video",
+        duration=60.0,
+        duration_string="1:00",
+        platform="Vimeo",
+        original_url="https://vimeo.com/123456",
+    )
+
+    app = _create_test_app()
+    app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(app)
+
+    resp = client.post(
+        "/video/details",
+        json={"url": "https://vimeo.com/123456"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Vimeo Video"
+    assert data["platform"] == "Vimeo"
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+def test_video_transcribe_endpoint_error(mock_transcribe, mock_register, mock_auth):
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.side_effect = Exception("yt-dlp download failed")
+
+    app = _create_test_app()
+    app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={"url": "https://invalid-site.com/video", "lang": "en", "response_format": "text"},
+    )
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["result"] is False
+    assert "yt-dlp download failed" in data["error"]
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `pytest tests/test_video.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_video.py
+git commit -m "test: add integration tests for video router endpoints"
+```
+
+---
+
+### Task 11: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pytest tests/ -v --tb=short`
+Expected: ALL existing tests PASS, all new tests PASS
+
+- [ ] **Step 2: Check linting**
+
+Run: `python -m py_compile app/routers/video.py && python -m py_compile app/video/loader.py && python -m py_compile app/video/metadata.py && python -m py_compile app/video/transcription.py && echo "All files compile OK"`
+Expected: "All files compile OK"
+
+- [ ] **Step 3: Start the server and verify endpoints appear**
+
+Run: `cd /Users/michmzr/1.Projects/transition-summarize-py && timeout 10 python -m uvicorn app.main:app --host 0.0.0.0 --port 8099 2>&1 | head -20 || true`
+
+Then check: `curl -s http://localhost:8099/url-list | python -m json.tool | grep video`
+Expected: `/video/transcribe`, `/video/summarize`, `/video/details` appear in the URL list
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete generic video processing endpoints for non-YouTube platforms"
+```

--- a/docs/superpowers/plans/2026-06-24-video-metadata-in-responses.md
+++ b/docs/superpowers/plans/2026-06-24-video-metadata-in-responses.md
@@ -1,0 +1,762 @@
+# Video Metadata in API Responses — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Return fetched video metadata (title, description, duration, etc.) in the response bodies of transcription and summarization endpoints. Additionally, use metadata as context for the generic `/video/summarize` endpoint (matching existing YouTube behavior).
+
+**Architecture:** yt-dlp already extracts descriptions and metadata for both YouTube and generic video URLs. The YouTube `/summarize` already uses metadata as LLM context via `build_youtube_summary_input()`, but no endpoint currently returns metadata in its response. We extend the response models with an optional `metadata` field and populate it in all relevant endpoints. For `/video/summarize`, we also add metadata-enriched summarization context (mirroring YouTube).
+
+**Tech Stack:** Python, FastAPI, Pydantic v2, yt-dlp
+
+---
+
+### Task 1: Add `metadata` field to response models
+
+**Files:**
+- Modify: `app/models.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_models_metadata.py
+def test_summary_result_accepts_metadata():
+    from app.models import SummaryResult
+    result = SummaryResult(summary="Test summary", metadata={"title": "Video", "description": "Desc"})
+    assert result.metadata == {"title": "Video", "description": "Desc"}
+
+
+def test_summary_result_metadata_defaults_to_none():
+    from app.models import SummaryResult
+    result = SummaryResult(summary="Test summary")
+    assert result.metadata is None
+
+
+def test_api_processing_result_accepts_metadata():
+    from app.models import ApiProcessingResult
+    result = ApiProcessingResult(result=True, metadata={"title": "Video"})
+    assert result.metadata == {"title": "Video"}
+
+
+def test_api_processing_result_metadata_defaults_to_none():
+    from app.models import ApiProcessingResult
+    result = ApiProcessingResult(result=True)
+    assert result.metadata is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_models_metadata.py -v`
+Expected: FAIL with validation error (metadata field not recognized)
+
+- [ ] **Step 3: Add metadata field to SummaryResult and ApiProcessingResult**
+
+In `app/models.py`, add `metadata` to both models:
+
+```python
+class ApiProcessingResult(BaseModel):
+    result: bool = Field(title="Success or error")
+    error: Optional[str] = Field(default=None, title="Error description")
+    text: Optional[str] = Field(default=None, title="Video transcription")
+    transcription: Optional[str] = Field(default=None, title="Transcription text")
+    format: Optional[WHISPER_RESPONSE_FORMAT] = Field(default=None, title="Response format")
+    metadata: Optional[dict] = Field(default=None, title="Video metadata (title, description, duration, etc.)")
+
+
+class SummaryResult(BaseModel):
+    summary: str
+    metadata: Optional[dict] = Field(default=None, title="Video metadata (title, description, duration, etc.)")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_models_metadata.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models.py tests/test_models_metadata.py
+git commit -m "feat: add optional metadata field to API response models"
+```
+
+---
+
+### Task 2: Return metadata in YouTube `/transcribe` response
+
+**Files:**
+- Modify: `app/routers/youtube.py`
+- Test: `tests/test_yt.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_yt.py`:
+
+```python
+@patch('app.routers.youtube.get_current_active_user')
+@patch('app.routers.youtube.register_new_process')
+@patch('app.routers.youtube.yt_transcribe')
+@patch('app.routers.youtube.get_youtube_metadata')
+@patch('app.routers.youtube.update_process_status')
+def test_youtube_transcribe_returns_metadata_in_response(
+        mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.auth import get_current_active_user
+    from app.models import YoutubeMetadata
+    from app.routers.youtube import yt_router
+
+    mock_auth.return_value = MagicMock(
+        id="00000000-0000-0000-0000-000000000001",
+        username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "00000000-0000-0000-0000-000000000002"
+    mock_metadata.return_value = YoutubeMetadata(
+        title="My Video",
+        description="A great description.",
+        duration=300.0,
+        duration_string="5:00")
+    mock_transcribe.return_value = "Hello world transcription."
+
+    test_app = FastAPI()
+    test_app.include_router(yt_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    response = client.post(
+        "/youtube/transcribe",
+        json={"url": "https://www.youtube.com/watch?v=test", "lang": "en", "response_format": "text"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "My Video"
+    assert data["metadata"]["description"] == "A great description."
+    assert data["metadata"]["duration"] == 300.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yt.py::test_youtube_transcribe_returns_metadata_in_response -v`
+Expected: FAIL (metadata not in response or `get_youtube_metadata` not called)
+
+- [ ] **Step 3: Modify YouTube transcribe endpoint to fetch and return metadata**
+
+In `app/routers/youtube.py`, update `yt_transcription()`:
+
+```python
+def yt_transcription(
+        request: Request,
+        yt_request: YTVideoTranscribe,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"yt transcribe - request details: {yt_request}")
+
+        process_id = register_new_process(
+            current_user,
+            request_type=RequestType.YOUTUBE,
+            request=request,
+            request_data={
+                "yt_request": yt_request.model_dump()}
+        )
+
+        yt_metadata = None
+        try:
+            yt_metadata = get_youtube_metadata(yt_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch YouTube metadata for transcription: '{metadata_error}'")
+
+        save_dir = save_dir_path(yt_request.url)
+        transcription = yt_transcribe(
+            yt_request.url,
+            save_dir,
+            yt_request.lang,
+            yt_request.response_format)
+
+        update_process_status(process_id, CompletedProcess(
+            user_id=current_user.id,
+            status=RequestStatus.COMPLETED,
+            result=transcription,
+            result_format=ProcessArtifactFormat.TEXT,
+            lang=yt_request.lang,
+            type=ProcessArtifactType.TRANSCRIPTION
+        ))
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(transcription)
+        else:
+            metadata_dict = yt_metadata.model_dump(exclude={"subtitles"}) if yt_metadata else None
+            return ApiProcessingResult(
+                result=True, error=None,
+                transcription=transcription,
+                format=yt_request.response_format,
+                metadata=metadata_dict)
+    except Exception as e:
+        logging.error(f"Error processing YouTube transcription: {str(e)}")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Internal server error: {str(e)}",
+        )
+```
+
+Key change: fetch `get_youtube_metadata` before transcription (it's cached, so reused if summarize is called next), serialize to dict excluding `subtitles` (large nested structures with URLs not useful in this context), pass to response.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yt.py::test_youtube_transcribe_returns_metadata_in_response -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/youtube.py tests/test_yt.py
+git commit -m "feat: return video metadata in YouTube transcribe response"
+```
+
+---
+
+### Task 3: Return metadata in YouTube `/summarize` response
+
+**Files:**
+- Modify: `app/routers/youtube.py`
+- Test: `tests/test_yt.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_yt.py`:
+
+```python
+@patch('app.routers.youtube.get_current_active_user')
+@patch('app.routers.youtube.register_new_process')
+@patch('app.routers.youtube.download_transcription')
+@patch('app.routers.youtube.get_youtube_metadata')
+@patch('app.routers.youtube.register_process_artifact')
+@patch('app.routers.youtube.summarize')
+@patch('app.routers.youtube.complete_process')
+def test_youtube_summarize_returns_metadata_in_response(
+        mock_complete, mock_summarize, mock_artifact, mock_metadata,
+        mock_download_transcription, mock_register, mock_auth):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.auth import get_current_active_user
+    from app.models import YoutubeMetadata
+    from app.routers.youtube import yt_router
+
+    mock_auth.return_value = MagicMock(
+        id="00000000-0000-0000-0000-000000000001",
+        username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "00000000-0000-0000-0000-000000000002"
+    mock_metadata.return_value = YoutubeMetadata(
+        title="Talk Title",
+        description="Some description.",
+        duration=600.0,
+        duration_string="10:00")
+    mock_download_transcription.return_value = "[00:00] Hello."
+    mock_summarize.return_value = "Summary of the talk."
+
+    test_app = FastAPI()
+    test_app.include_router(yt_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    response = client.post(
+        "/youtube/summarize",
+        json={"url": "https://www.youtube.com/watch?v=test", "type": "detailed", "lang": "en", "use_yt_transcription": True})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Talk Title"
+    assert data["metadata"]["description"] == "Some description."
+    assert data["metadata"]["duration"] == 600.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yt.py::test_youtube_summarize_returns_metadata_in_response -v`
+Expected: FAIL (metadata not in response)
+
+- [ ] **Step 3: Modify YouTube summarize endpoint to include metadata in response**
+
+In `app/routers/youtube.py`, update the return statement in `yt_summarize()`:
+
+Change:
+```python
+return SummaryResult(summary=summarization)
+```
+
+To:
+```python
+metadata_dict = yt_metadata.model_dump(exclude={"subtitles"}) if yt_metadata else None
+return SummaryResult(summary=summarization, metadata=metadata_dict)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yt.py::test_youtube_summarize_returns_metadata_in_response -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/youtube.py tests/test_yt.py
+git commit -m "feat: return video metadata in YouTube summarize response"
+```
+
+---
+
+### Task 4: Add metadata context to `/video/summarize` and return in response
+
+**Files:**
+- Modify: `app/routers/video.py`
+- Test: `tests/test_video.py`
+
+The `/video/summarize` currently sends raw transcription to `summarize()` without any metadata context. The YouTube equivalent already enriches the prompt with title/duration/description via `build_youtube_summary_input()`. We reuse the same pattern here with a `build_video_summary_input()` function and return metadata in the response.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_video.py`:
+
+```python
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_passes_metadata_context_and_returns_it(
+        mock_complete, mock_summarize, mock_artifact,
+        mock_metadata, mock_transcribe, mock_register, mock_auth):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.models import VideoMetadata
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_metadata.return_value = VideoMetadata(
+        title="Vimeo Talk",
+        description="An insightful presentation about testing.",
+        duration=900.0,
+        duration_string="15:00",
+        platform="Vimeo",
+        original_url="https://vimeo.com/789")
+    mock_transcribe.return_value = "This is the transcribed text."
+    mock_summarize.return_value = "Summary of the vimeo talk."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://vimeo.com/789", "type": "detailed", "lang": "en"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Verify metadata is in response
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Vimeo Talk"
+    assert data["metadata"]["description"] == "An insightful presentation about testing."
+
+    # Verify metadata was used as context for summarization
+    text_sent_to_model = mock_summarize.call_args.args[0]
+    assert "Title: Vimeo Talk" in text_sent_to_model
+    assert "Duration: 15:00" in text_sent_to_model
+    assert "Description: An insightful presentation about testing." in text_sent_to_model
+    assert "Transcript:" in text_sent_to_model
+    assert "This is the transcribed text." in text_sent_to_model
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_video.py::test_video_summarize_passes_metadata_context_and_returns_it -v`
+Expected: FAIL (get_video_metadata not patched/called in summarize, metadata not in response)
+
+- [ ] **Step 3: Add `build_video_summary_input` and update video summarize endpoint**
+
+In `app/routers/video.py`:
+
+1. Add import for the `_trim_metadata_text` helper (extract to shared util or duplicate):
+
+```python
+from app.models import (
+    VideoTranscribe, VideoSummarize, VideoInfoRequest,
+    VideoMetadata, SummaryResult, ApiProcessingResult,
+)
+```
+
+2. Add `build_video_summary_input` function:
+
+```python
+def _trim_metadata_text(text: str, max_length: int = 2000) -> str:
+    cleaned_text = " ".join(text.split())
+    if len(cleaned_text) <= max_length:
+        return cleaned_text
+    return f"{cleaned_text[:max_length].rstrip()}..."
+
+
+def build_video_summary_input(
+        transcription: str,
+        metadata: VideoMetadata | None
+) -> str:
+    if not metadata:
+        return transcription
+
+    metadata_lines = []
+    if metadata.title:
+        metadata_lines.append(f"Title: {metadata.title}")
+    if metadata.duration_string:
+        metadata_lines.append(f"Duration: {metadata.duration_string}")
+    elif metadata.duration:
+        metadata_lines.append(f"Duration: {metadata.duration} seconds")
+    if metadata.description:
+        metadata_lines.append(
+            f"Description: {_trim_metadata_text(metadata.description)}")
+
+    if not metadata_lines:
+        return transcription
+
+    return "\n".join([
+        "Video metadata:",
+        *metadata_lines,
+        "",
+        "Transcript:",
+        transcription
+    ])
+```
+
+3. Update `video_summarize()` endpoint to fetch metadata, use as context, and return in response:
+
+```python
+def video_summarize(
+        request: Request,
+        video_request: VideoSummarize,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video summarize - Request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        save_dir = save_dir_path(video_request.url)
+
+        video_metadata = None
+        try:
+            video_metadata = get_video_metadata(video_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch video metadata for summarization: '{metadata_error}'")
+
+        transcription = video_transcribe(
+            video_request.url, save_dir, video_request.lang,
+            WHISPER_RESPONSE_FORMAT.TEXT)
+
+        if not transcription.strip():
+            raise ValueError(
+                "No transcription generated from video audio. The source may have no detectable speech.")
+
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.TRANSCRIPTION,
+            transcription,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        summary_input = build_video_summary_input(transcription, video_metadata)
+        summarization = summarize(
+            summary_input, video_request.type, video_request.lang)
+        register_process_artifact(
+            current_user, process_id,
+            ProcessArtifactType.SUMMARY,
+            summarization,
+            ProcessArtifactFormat.TEXT, video_request.lang)
+
+        logging.debug(f"video summarize - Result: \n{summarization}")
+
+        complete_process(process_id)
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(summarization)
+        elif accept_header == "text/srt":
+            return FileResponse(transcription, media_type="text/srt")
+        else:
+            metadata_dict = video_metadata.model_dump(exclude={"subtitles"}) if video_metadata else None
+            return SummaryResult(summary=summarization, metadata=metadata_dict)
+    except Exception as e:
+        logging.error(f"Error processing video summarization: '{str(e)}'")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error="Error processing video summarization",
+            text=str(e))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_video.py::test_video_summarize_passes_metadata_context_and_returns_it -v`
+Expected: PASS
+
+- [ ] **Step 5: Run existing video tests to verify no regressions**
+
+Run: `uv run pytest tests/test_video.py -v`
+Expected: All existing tests PASS (the existing `test_video_summarize_endpoint_success` test does not mock `get_video_metadata` — it needs updating since the function is now called. Add patch for it.)
+
+- [ ] **Step 6: Fix existing test for video summarize**
+
+Update `test_video_summarize_endpoint_success` in `tests/test_video.py` to also mock `get_video_metadata`:
+
+```python
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_endpoint_success(
+    mock_complete, mock_summarize, mock_artifact,
+    mock_metadata, mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_metadata.return_value = None
+    mock_transcribe.return_value = "Transcribed text."
+    mock_summarize.return_value = "This is a summary of the video."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://vimeo.com/123456", "type": "tldr", "lang": "en"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"] == "This is a summary of the video."
+```
+
+Also update `test_video_summarize_endpoint_rejects_empty_transcription` similarly with the `get_video_metadata` patch.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/routers/video.py tests/test_video.py
+git commit -m "feat: fetch metadata for video summarization context and return in response"
+```
+
+---
+
+### Task 5: Return metadata in `/video/transcribe` response
+
+**Files:**
+- Modify: `app/routers/video.py`
+- Test: `tests/test_video.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_video.py`:
+
+```python
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.update_process_status')
+def test_video_transcribe_returns_metadata_in_response(
+    mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.models import VideoMetadata
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_metadata.return_value = VideoMetadata(
+        title="Instagram Reel",
+        description="Short video about cooking.",
+        duration=30.0,
+        duration_string="0:30",
+        platform="Instagram")
+    mock_transcribe.return_value = "Today we cook pasta."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={"url": "https://www.instagram.com/reel/abc", "lang": "en", "response_format": "text"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Instagram Reel"
+    assert data["metadata"]["description"] == "Short video about cooking."
+    assert data["metadata"]["platform"] == "Instagram"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_video.py::test_video_transcribe_returns_metadata_in_response -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify video transcribe endpoint to fetch and return metadata**
+
+In `app/routers/video.py`, update `video_transcription()`:
+
+```python
+def video_transcription(
+        request: Request,
+        video_request: VideoTranscribe,
+        response: Response,
+        current_user: User = Depends(get_current_active_user)
+):
+    process_id = None
+    try:
+        logging.info(f"video transcribe - request details: {video_request}")
+
+        process_id = register_new_process(
+            current_user,
+            request_type=RequestType.VIDEO,
+            request=request,
+            request_data={"video_request": video_request.model_dump()}
+        )
+
+        video_metadata = None
+        try:
+            video_metadata = get_video_metadata(video_request.url)
+        except Exception as metadata_error:
+            logging.warning(
+                f"Could not fetch video metadata for transcription: '{metadata_error}'")
+
+        save_dir = save_dir_path(video_request.url)
+        transcription = video_transcribe(
+            video_request.url,
+            save_dir,
+            video_request.lang,
+            video_request.response_format)
+
+        update_process_status(process_id, CompletedProcess(
+            user_id=current_user.id,
+            status=RequestStatus.COMPLETED,
+            result=transcription,
+            result_format=ProcessArtifactFormat.TEXT,
+            lang=video_request.lang,
+            type=ProcessArtifactType.TRANSCRIPTION
+        ))
+
+        accept_header = request.headers.get("Accept", "application/json")
+        if accept_header == "text/plain":
+            return PlainTextResponse(transcription)
+        else:
+            metadata_dict = video_metadata.model_dump(exclude={"subtitles"}) if video_metadata else None
+            return ApiProcessingResult(
+                result=True, error=None,
+                transcription=transcription,
+                format=video_request.response_format,
+                metadata=metadata_dict)
+    except Exception as e:
+        logging.error(f"Error processing video transcription: {str(e)}")
+
+        if process_id:
+            process_failed(process_id, str(e))
+
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return ApiProcessingResult(
+            result=False,
+            error=f"Internal server error: {str(e)}",
+        )
+```
+
+- [ ] **Step 4: Update existing transcribe test to patch metadata**
+
+Update `test_video_transcribe_endpoint_success` in `tests/test_video.py` to add `get_video_metadata` patch:
+
+```python
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.update_process_status')
+def test_video_transcribe_endpoint_success(
+    mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth
+):
+    # ... same body but add:
+    mock_metadata.return_value = None
+    # rest stays the same
+```
+
+Also update `test_video_transcribe_endpoint_error` to add the `get_video_metadata` patch.
+
+- [ ] **Step 5: Run all video tests**
+
+Run: `uv run pytest tests/test_video.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/routers/video.py tests/test_video.py
+git commit -m "feat: return video metadata in video transcribe response"
+```
+
+---
+
+### Task 6: Run full test suite and verify
+
+- [ ] **Step 1: Run all tests**
+
+Run: `uv run pytest tests/ -v`
+Expected: All PASS
+
+- [ ] **Step 2: Start the app and verify no import errors**
+
+Run: `uv run -m app`
+Expected: FastAPI starts without errors
+
+- [ ] **Step 3: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git commit -m "chore: cleanup after metadata-in-responses feature"
+```

--- a/readme.md
+++ b/readme.md
@@ -4,37 +4,37 @@
 #### First Time Setup
 1. Initialize Alembic (if not done before):
 ```bash
-alembic init alembic
+uv alembic init alembic
 ```
 
 2. Initialize the database schema:
 ```bash
-alembic stamp head
+uv alembic stamp head
 ```
 
 3. Run the initial migration:
 ```bash
-alembic upgrade head
+uv alembic upgrade head
 ```
 
 #### Create a new migration:
 1. Create a new migration:
 ```bash
-alembic revision --autogenerate -m "migration name"
+uv alembic revision --autogenerate -m "migration name"
 ```
 
 2. Apply pending migrations:
 ```bash
-alembic upgrade head
+uv alembic upgrade head
 ```
 
 3. Check migration status:
 ```bash
-alembic current
+uv alembic current
 ```
 
 ```bash
-alembic history
+uv alembic history
 ```
 
 #### Troubleshooting
@@ -42,12 +42,12 @@ alembic history
 If you need to reset the database:
 1. Drop all tables:
 ```bash
-alembic downgrade base
+uv alembic downgrade base
 ```
 
 2. Reapply all migrations:
 ```bash
-alembic upgrade head
+uv alembic upgrade head
 ```
 
 ## Running the Application
@@ -60,7 +60,7 @@ docker-compose --env-file ./.env -f ./deploy/docker-compose.yml up
 
 2. Ensure database schema is up to date:
 ```bash
-alembic upgrade head
+uv alembic upgrade head
 ```
 
 3. Run the application:

--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -1,0 +1,33 @@
+def test_summary_result_accepts_metadata():
+    from app.models import SummaryResult
+
+    result = SummaryResult(
+        summary="Test summary",
+        metadata={"title": "Video", "description": "Desc"},
+    )
+
+    assert result.metadata == {"title": "Video", "description": "Desc"}
+
+
+def test_summary_result_metadata_defaults_to_none():
+    from app.models import SummaryResult
+
+    result = SummaryResult(summary="Test summary")
+
+    assert result.metadata is None
+
+
+def test_api_processing_result_accepts_metadata():
+    from app.models import ApiProcessingResult
+
+    result = ApiProcessingResult(result=True, metadata={"title": "Video"})
+
+    assert result.metadata == {"title": "Video"}
+
+
+def test_api_processing_result_metadata_defaults_to_none():
+    from app.models import ApiProcessingResult
+
+    result = ApiProcessingResult(result=True)
+
+    assert result.metadata is None

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -145,21 +145,21 @@ def test_video_router_has_transcribe_endpoint():
     mod = importlib.import_module("app.routers.video")
     router = mod.video_router
     paths = [route.path for route in router.routes]
-    assert "/transcribe" in paths
+    assert "/video/transcribe" in paths
 
 
 def test_video_router_has_summarize_endpoint():
     mod = importlib.import_module("app.routers.video")
     router = mod.video_router
     paths = [route.path for route in router.routes]
-    assert "/summarize" in paths
+    assert "/video/summarize" in paths
 
 
 def test_video_router_has_details_endpoint():
     mod = importlib.import_module("app.routers.video")
     router = mod.video_router
     paths = [route.path for route in router.routes]
-    assert "/details" in paths
+    assert "/video/details" in paths
 
 
 def test_video_router_prefix():
@@ -180,8 +180,10 @@ def test_video_transcribe_endpoint_success(
     from app.routers.video import video_router
     from app.auth import get_current_active_user
 
-    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
-    mock_register.return_value = "process-uuid-1"
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
     mock_transcribe.return_value = "Transcribed text from Vimeo video."
 
     test_app = FastAPI()
@@ -214,8 +216,10 @@ def test_video_summarize_endpoint_success(
     from app.routers.video import video_router
     from app.auth import get_current_active_user
 
-    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
-    mock_register.return_value = "process-uuid-1"
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
     mock_transcribe.return_value = "Transcribed text."
     mock_summarize.return_value = "This is a summary of the video."
 
@@ -242,7 +246,8 @@ def test_video_details_endpoint_success(mock_metadata, mock_auth):
     from app.routers.video import video_router
     from app.auth import get_current_active_user
 
-    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    user_id = "00000000-0000-0000-0000-000000000001"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
     mock_metadata.return_value = VideoMetadata(
         title="Vimeo Video",
         description="A cool video",
@@ -270,14 +275,17 @@ def test_video_details_endpoint_success(mock_metadata, mock_auth):
 @patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.register_new_process')
 @patch('app.routers.video.video_transcribe')
-def test_video_transcribe_endpoint_error(mock_transcribe, mock_register, mock_auth):
+@patch('app.routers.video.process_failed')
+def test_video_transcribe_endpoint_error(mock_process_failed, mock_transcribe, mock_register, mock_auth):
     from fastapi.testclient import TestClient
     from fastapi import FastAPI
     from app.routers.video import video_router
     from app.auth import get_current_active_user
 
-    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
-    mock_register.return_value = "process-uuid-1"
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
     mock_transcribe.side_effect = Exception("yt-dlp download failed")
 
     test_app = FastAPI()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -204,12 +204,13 @@ def test_video_transcribe_endpoint_success(
 @patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.register_new_process')
 @patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
 @patch('app.routers.video.register_process_artifact')
 @patch('app.routers.video.summarize')
 @patch('app.routers.video.complete_process')
 def test_video_summarize_endpoint_success(
     mock_complete, mock_summarize, mock_artifact,
-    mock_transcribe, mock_register, mock_auth
+    mock_metadata, mock_transcribe, mock_register, mock_auth
 ):
     from fastapi.testclient import TestClient
     from fastapi import FastAPI
@@ -220,6 +221,7 @@ def test_video_summarize_endpoint_success(
     process_id = "00000000-0000-0000-0000-000000000002"
     mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
     mock_register.return_value = process_id
+    mock_metadata.return_value = None
     mock_transcribe.return_value = "Transcribed text."
     mock_summarize.return_value = "This is a summary of the video."
 
@@ -240,13 +242,68 @@ def test_video_summarize_endpoint_success(
 @patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.register_new_process')
 @patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_passes_metadata_context_and_returns_it(
+        mock_complete, mock_summarize, mock_artifact,
+        mock_metadata, mock_transcribe, mock_register, mock_auth):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.models import VideoMetadata
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_metadata.return_value = VideoMetadata(
+        title="Vimeo Talk",
+        description="An insightful presentation about testing.",
+        duration=900.0,
+        duration_string="15:00",
+        platform="Vimeo",
+        original_url="https://vimeo.com/789")
+    mock_transcribe.return_value = "This is the transcribed text."
+    mock_summarize.return_value = "Summary of the vimeo talk."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://vimeo.com/789", "type": "detailed", "lang": "en"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Vimeo Talk"
+    assert data["metadata"]["description"] == "An insightful presentation about testing."
+
+    text_sent_to_model = mock_summarize.call_args.args[0]
+    assert "Title: Vimeo Talk" in text_sent_to_model
+    assert "Duration: 15:00" in text_sent_to_model
+    assert "Description: An insightful presentation about testing." in text_sent_to_model
+    assert "Transcript:" in text_sent_to_model
+    assert "This is the transcribed text." in text_sent_to_model
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
 @patch('app.routers.video.register_process_artifact')
 @patch('app.routers.video.process_failed')
 @patch('app.routers.video.summarize')
 @patch('app.routers.video.complete_process')
 def test_video_summarize_endpoint_rejects_empty_transcription(
     mock_complete, mock_summarize, mock_process_failed,
-    mock_artifact, mock_transcribe, mock_register, mock_auth
+    mock_artifact, mock_metadata, mock_transcribe, mock_register, mock_auth
 ):
     from fastapi.testclient import TestClient
     from fastapi import FastAPI
@@ -257,6 +314,7 @@ def test_video_summarize_endpoint_rejects_empty_transcription(
     process_id = "00000000-0000-0000-0000-000000000002"
     mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
     mock_register.return_value = process_id
+    mock_metadata.return_value = None
     mock_transcribe.return_value = ""
     mock_summarize.return_value = ""
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -171,9 +171,10 @@ def test_video_router_prefix():
 @patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.register_new_process')
 @patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
 @patch('app.routers.video.update_process_status')
 def test_video_transcribe_endpoint_success(
-    mock_update, mock_transcribe, mock_register, mock_auth
+    mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth
 ):
     from fastapi.testclient import TestClient
     from fastapi import FastAPI
@@ -184,6 +185,7 @@ def test_video_transcribe_endpoint_success(
     process_id = "00000000-0000-0000-0000-000000000002"
     mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
     mock_register.return_value = process_id
+    mock_metadata.return_value = None
     mock_transcribe.return_value = "Transcribed text from Vimeo video."
 
     test_app = FastAPI()
@@ -199,6 +201,53 @@ def test_video_transcribe_endpoint_success(
     data = resp.json()
     assert data["result"] is True
     assert data["transcription"] == "Transcribed text from Vimeo video."
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
+@patch('app.routers.video.update_process_status')
+def test_video_transcribe_returns_metadata_in_response(
+    mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.models import VideoMetadata
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_metadata.return_value = VideoMetadata(
+        title="Instagram Reel",
+        description="Short video about cooking.",
+        duration=30.0,
+        duration_string="0:30",
+        platform="Instagram")
+    mock_transcribe.return_value = "Today we cook pasta."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={
+            "url": "https://www.instagram.com/reel/abc",
+            "lang": "en",
+            "response_format": "text"
+        })
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Instagram Reel"
+    assert data["metadata"]["description"] == "Short video about cooking."
+    assert data["metadata"]["platform"] == "Instagram"
 
 
 @patch('app.routers.video.get_current_active_user')
@@ -375,8 +424,10 @@ def test_video_details_endpoint_success(mock_metadata, mock_auth):
 @patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.register_new_process')
 @patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.get_video_metadata')
 @patch('app.routers.video.process_failed')
-def test_video_transcribe_endpoint_error(mock_process_failed, mock_transcribe, mock_register, mock_auth):
+def test_video_transcribe_endpoint_error(
+        mock_process_failed, mock_metadata, mock_transcribe, mock_register, mock_auth):
     from fastapi.testclient import TestClient
     from fastapi import FastAPI
     from app.routers.video import video_router
@@ -386,6 +437,7 @@ def test_video_transcribe_endpoint_error(mock_process_failed, mock_transcribe, m
     process_id = "00000000-0000-0000-0000-000000000002"
     mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
     mock_register.return_value = process_id
+    mock_metadata.return_value = None
     mock_transcribe.side_effect = Exception("yt-dlp download failed")
 
     test_app = FastAPI()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,295 @@
+import importlib
+from unittest.mock import patch, MagicMock
+
+from app.schema.models import RequestType
+
+
+def test_video_request_type_exists():
+    assert RequestType.VIDEO.value == "video"
+
+
+def test_register_new_process_video_type():
+    from app.processing.processing import register_new_process
+    from app.schema.models import RequestType, UserProcessSourceType
+
+    mock_user = MagicMock()
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
+
+    mock_request = MagicMock()
+    mock_request.url = "http://test"
+    mock_request.method = "POST"
+
+    mock_db = MagicMock()
+    mock_process = MagicMock()
+    mock_process.id = "00000000-0000-0000-0000-000000000002"
+    mock_db.return_value = mock_db
+    mock_db.add = MagicMock()
+    mock_db.commit = MagicMock()
+    mock_db.refresh = MagicMock(side_effect=lambda p: setattr(p, 'id', mock_process.id))
+    mock_db.close = MagicMock()
+
+    with patch('app.processing.processing.get_session_maker', return_value=lambda: mock_db):
+        result = register_new_process(
+            mock_user,
+            RequestType.VIDEO,
+            request=mock_request,
+            request_data={"url": "https://vimeo.com/123"}
+        )
+
+    call_args = mock_db.add.call_args[0][0]
+    assert call_args.source_type == UserProcessSourceType.URL
+    assert call_args.type == RequestType.VIDEO
+
+
+def test_video_audio_loader_init():
+    from app.video.loader import VideoAudioLoader
+    loader = VideoAudioLoader(["https://vimeo.com/123456"], "/tmp/test_save")
+    assert loader.urls == ["https://vimeo.com/123456"]
+    assert loader.save_dir == "/tmp/test_save"
+    assert loader.proxy_servers is None
+
+
+def test_video_audio_loader_init_with_proxy():
+    from app.video.loader import VideoAudioLoader
+    loader = VideoAudioLoader(
+        ["https://vimeo.com/123456"],
+        "/tmp/test_save",
+        proxy_servers=["http://proxy1:8080"]
+    )
+    assert loader.proxy_servers == ["http://proxy1:8080"]
+
+
+def test_video_audio_loader_urls_must_be_list():
+    from app.video.loader import VideoAudioLoader
+    try:
+        VideoAudioLoader("https://vimeo.com/123456", "/tmp/test_save")
+        assert False, "Should have raised TypeError"
+    except TypeError:
+        pass
+
+
+def test_video_metadata_model():
+    from app.models import VideoMetadata
+    metadata = VideoMetadata(
+        title="Test Video",
+        description="A test video",
+        duration=120.5,
+        duration_string="2:00",
+        platform="vimeo",
+        original_url="https://vimeo.com/123456",
+    )
+    assert metadata.title == "Test Video"
+    assert metadata.platform == "vimeo"
+    assert metadata.duration == 120.5
+    assert metadata.thumbnail is None
+    assert metadata.uploader is None
+
+
+def test_video_transcribe_model_defaults():
+    from app.models import VideoTranscribe
+    from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT
+    req = VideoTranscribe(url="https://vimeo.com/123456")
+    assert req.url == "https://vimeo.com/123456"
+    assert req.lang == LANG_CODE.POLISH
+    assert req.response_format == WHISPER_RESPONSE_FORMAT.SRT
+
+
+def test_video_summarize_model_defaults():
+    from app.models import VideoSummarize, SUMMARIZATION_TYPE
+    from app.transcribe.transcription import LANG_CODE
+    req = VideoSummarize(url="https://vimeo.com/123456")
+    assert req.url == "https://vimeo.com/123456"
+    assert req.type == SUMMARIZATION_TYPE.TLDR
+    assert req.lang == LANG_CODE.POLISH
+
+
+def test_video_info_request_model():
+    from app.models import VideoInfoRequest
+    req = VideoInfoRequest(url="https://www.instagram.com/reel/abc123")
+    assert req.url == "https://www.instagram.com/reel/abc123"
+
+
+@patch('app.video.transcription.GenericLoader')
+@patch('app.video.transcription.get_settings')
+def test_video_transcribe_returns_text(mock_settings, mock_generic_loader):
+    from app.video.transcription import video_transcribe
+    from app.transcribe.transcription import LANG_CODE, WHISPER_RESPONSE_FORMAT
+
+    mock_settings_obj = MagicMock()
+    mock_settings_obj.openai_api_key = "test-key"
+    mock_settings_obj.proxy_servers = ""
+    mock_settings_obj.use_proxy = False
+    mock_settings.return_value = mock_settings_obj
+
+    mock_doc = MagicMock()
+    mock_doc.page_content = "Hello, this is a test transcription."
+    mock_generic_loader.return_value.load.return_value = [mock_doc]
+
+    result = video_transcribe(
+        "https://vimeo.com/123",
+        "/tmp/test",
+        LANG_CODE.ENGLISH,
+        WHISPER_RESPONSE_FORMAT.TEXT
+    )
+
+    assert result == "Hello, this is a test transcription."
+    mock_generic_loader.assert_called_once()
+
+
+def test_video_router_module_loads():
+    mod = importlib.import_module("app.routers.video")
+    assert hasattr(mod, "video_router")
+
+
+def test_video_router_has_transcribe_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/transcribe" in paths
+
+
+def test_video_router_has_summarize_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/summarize" in paths
+
+
+def test_video_router_has_details_endpoint():
+    mod = importlib.import_module("app.routers.video")
+    router = mod.video_router
+    paths = [route.path for route in router.routes]
+    assert "/details" in paths
+
+
+def test_video_router_prefix():
+    from app.routers.video import video_router
+    assert video_router.prefix == "/video"
+    assert "video" in video_router.tags
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.update_process_status')
+def test_video_transcribe_endpoint_success(
+    mock_update, mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.return_value = "Transcribed text from Vimeo video."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={"url": "https://vimeo.com/123456", "lang": "en", "response_format": "text"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["result"] is True
+    assert data["transcription"] == "Transcribed text from Vimeo video."
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_endpoint_success(
+    mock_complete, mock_summarize, mock_artifact,
+    mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.return_value = "Transcribed text."
+    mock_summarize.return_value = "This is a summary of the video."
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://vimeo.com/123456", "type": "tldr", "lang": "en"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"] == "This is a summary of the video."
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.get_video_metadata')
+def test_video_details_endpoint_success(mock_metadata, mock_auth):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.models import VideoMetadata
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_metadata.return_value = VideoMetadata(
+        title="Vimeo Video",
+        description="A cool video",
+        duration=60.0,
+        duration_string="1:00",
+        platform="Vimeo",
+        original_url="https://vimeo.com/123456",
+    )
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/details",
+        json={"url": "https://vimeo.com/123456"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Vimeo Video"
+    assert data["platform"] == "Vimeo"
+
+
+@patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+def test_video_transcribe_endpoint_error(mock_transcribe, mock_register, mock_auth):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    mock_auth.return_value = MagicMock(id="user-1", username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = "process-uuid-1"
+    mock_transcribe.side_effect = Exception("yt-dlp download failed")
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/transcribe",
+        json={"url": "https://invalid-site.com/video", "lang": "en", "response_format": "text"},
+    )
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["result"] is False
+    assert "yt-dlp download failed" in data["error"]

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -238,6 +238,48 @@ def test_video_summarize_endpoint_success(
 
 
 @patch('app.routers.video.get_current_active_user')
+@patch('app.routers.video.register_new_process')
+@patch('app.routers.video.video_transcribe')
+@patch('app.routers.video.register_process_artifact')
+@patch('app.routers.video.process_failed')
+@patch('app.routers.video.summarize')
+@patch('app.routers.video.complete_process')
+def test_video_summarize_endpoint_rejects_empty_transcription(
+    mock_complete, mock_summarize, mock_process_failed,
+    mock_artifact, mock_transcribe, mock_register, mock_auth
+):
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from app.routers.video import video_router
+    from app.auth import get_current_active_user
+
+    user_id = "00000000-0000-0000-0000-000000000001"
+    process_id = "00000000-0000-0000-0000-000000000002"
+    mock_auth.return_value = MagicMock(id=user_id, username="test", email="t@t.com", is_active=True)
+    mock_register.return_value = process_id
+    mock_transcribe.return_value = ""
+    mock_summarize.return_value = ""
+
+    test_app = FastAPI()
+    test_app.include_router(video_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    resp = client.post(
+        "/video/summarize",
+        json={"url": "https://www.instagram.com/p/test", "type": "tldr", "lang": "pl"},
+    )
+
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["error"] == "Error processing video summarization"
+    assert "No transcription generated" in data["text"]
+    mock_summarize.assert_not_called()
+    mock_complete.assert_not_called()
+    mock_process_failed.assert_called_once()
+
+
+@patch('app.routers.video.get_current_active_user')
 @patch('app.routers.video.get_video_metadata')
 def test_video_details_endpoint_success(mock_metadata, mock_auth):
     from fastapi.testclient import TestClient

--- a/tests/test_yt.py
+++ b/tests/test_yt.py
@@ -149,5 +149,57 @@ def test_youtube_transcribe_returns_metadata_in_response(
     assert data["metadata"]["duration"] == 300.0
 
 
+@patch('app.routers.youtube.get_current_active_user')
+@patch('app.routers.youtube.register_new_process')
+@patch('app.routers.youtube.download_transcription')
+@patch('app.routers.youtube.get_youtube_metadata')
+@patch('app.routers.youtube.register_process_artifact')
+@patch('app.routers.youtube.summarize')
+@patch('app.routers.youtube.complete_process')
+def test_youtube_summarize_returns_metadata_in_response(
+        mock_complete, mock_summarize, mock_artifact, mock_metadata,
+        mock_download_transcription, mock_register, mock_auth):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.auth import get_current_active_user
+    from app.models import YoutubeMetadata
+    from app.routers.youtube import yt_router
+
+    mock_auth.return_value = MagicMock(
+        id="00000000-0000-0000-0000-000000000001",
+        username="test",
+        email="t@t.com",
+        is_active=True)
+    mock_register.return_value = "00000000-0000-0000-0000-000000000002"
+    mock_metadata.return_value = YoutubeMetadata(
+        title="Talk Title",
+        description="Some description.",
+        duration=600.0,
+        duration_string="10:00")
+    mock_download_transcription.return_value = "[00:00] Hello."
+    mock_summarize.return_value = "Summary of the talk."
+
+    test_app = FastAPI()
+    test_app.include_router(yt_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    response = client.post(
+        "/youtube/summarize",
+        json={
+            "url": "https://www.youtube.com/watch?v=test",
+            "type": "detailed",
+            "lang": "en",
+            "use_yt_transcription": True
+        })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "Talk Title"
+    assert data["metadata"]["description"] == "Some description."
+    assert data["metadata"]["duration"] == 600.0
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_yt.py
+++ b/tests/test_yt.py
@@ -102,5 +102,52 @@ def test_youtube_summarize_passes_metadata_and_transcription_to_model(
     assert "Transcript:\n[00:00] Intro to research." in text_sent_to_model
 
 
+@patch('app.routers.youtube.get_current_active_user')
+@patch('app.routers.youtube.register_new_process')
+@patch('app.routers.youtube.yt_transcribe')
+@patch('app.routers.youtube.get_youtube_metadata')
+@patch('app.routers.youtube.update_process_status')
+def test_youtube_transcribe_returns_metadata_in_response(
+        mock_update, mock_metadata, mock_transcribe, mock_register, mock_auth):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.auth import get_current_active_user
+    from app.models import YoutubeMetadata
+    from app.routers.youtube import yt_router
+
+    mock_auth.return_value = MagicMock(
+        id="00000000-0000-0000-0000-000000000001",
+        username="test",
+        email="t@t.com",
+        is_active=True)
+    mock_register.return_value = "00000000-0000-0000-0000-000000000002"
+    mock_metadata.return_value = YoutubeMetadata(
+        title="My Video",
+        description="A great description.",
+        duration=300.0,
+        duration_string="5:00")
+    mock_transcribe.return_value = "Hello world transcription."
+
+    test_app = FastAPI()
+    test_app.include_router(yt_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    response = client.post(
+        "/youtube/transcribe",
+        json={
+            "url": "https://www.youtube.com/watch?v=test",
+            "lang": "en",
+            "response_format": "text"
+        })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metadata"] is not None
+    assert data["metadata"]["title"] == "My Video"
+    assert data["metadata"]["description"] == "A great description."
+    assert data["metadata"]["duration"] == 300.0
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_yt.py
+++ b/tests/test_yt.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from app.youtube.metadata import get_youtube_metadata
 
@@ -25,6 +26,80 @@ class YTMetadata(unittest.TestCase):
 
         self.assertIsNotNone(metadata.upload_date)
         self.assertIsNotNone(metadata.thumbnail)
+
+
+def test_normalize_vtt_transcription_returns_timestamped_text():
+    from app.youtube.transcriptions import normalize_vtt_transcription
+
+    raw_vtt = """WEBVTT
+
+00:00:00.000 --> 00:00:03.500
+First sentence.
+
+00:00:03.500 --> 00:00:07.200
+Second sentence.
+"""
+
+    transcription = normalize_vtt_transcription(raw_vtt)
+
+    assert transcription == "[00:00] First sentence.\n[00:03] Second sentence."
+
+
+@patch('app.routers.youtube.get_current_active_user')
+@patch('app.routers.youtube.register_new_process')
+@patch('app.routers.youtube.download_transcription')
+@patch('app.routers.youtube.get_youtube_metadata')
+@patch('app.routers.youtube.register_process_artifact')
+@patch('app.routers.youtube.summarize')
+@patch('app.routers.youtube.complete_process')
+def test_youtube_summarize_passes_metadata_and_transcription_to_model(
+        mock_complete,
+        mock_summarize,
+        mock_artifact,
+        mock_metadata,
+        mock_download_transcription,
+        mock_register,
+        mock_auth):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.auth import get_current_active_user
+    from app.models import YoutubeMetadata
+    from app.routers.youtube import yt_router
+
+    mock_auth.return_value = MagicMock(
+        id="00000000-0000-0000-0000-000000000001",
+        username="test",
+        email="t@t.com",
+        is_active=True)
+    mock_register.return_value = "00000000-0000-0000-0000-000000000002"
+    mock_metadata.return_value = YoutubeMetadata(
+        title="Research Talk",
+        description="A lecture about AI research.",
+        duration=120.0,
+        duration_string="2:00")
+    mock_download_transcription.return_value = "[00:00] Intro to research."
+    mock_summarize.return_value = "Summary text."
+
+    test_app = FastAPI()
+    test_app.include_router(yt_router)
+    test_app.dependency_overrides[get_current_active_user] = lambda: mock_auth.return_value
+    client = TestClient(test_app)
+
+    response = client.post(
+        "/youtube/summarize",
+        json={
+            "url": "https://www.youtube.com/watch?v=test",
+            "type": "detailed",
+            "lang": "en",
+            "use_yt_transcription": True
+        })
+
+    assert response.status_code == 200
+    text_sent_to_model = mock_summarize.call_args.args[0]
+    assert "Title: Research Talk" in text_sent_to_model
+    assert "Duration: 2:00" in text_sent_to_model
+    assert "Description: A lecture about AI research." in text_sent_to_model
+    assert "Transcript:\n[00:00] Intro to research." in text_sent_to_model
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Rozszerza API o obsługę **dowolnych URL-i wideo** obsługiwanych przez yt-dlp (Vimeo, Instagram itd.) — analogicznie do istniejących endpointów YouTube i audio.

### Nowe endpointy (`/video`)

| Endpoint | Opis |
|----------|------|
| `POST /video/transcribe` | Pobiera audio z URL, transkrybuje (Whisper). Zwraca JSON lub `text/plain` (nagłówek `Accept`). |
| `POST /video/summarize` | Transkrypcja + podsumowanie LLM. Zwraca JSON, `text/plain` lub `text/srt` (transkrypcja). |
| `POST /video/details` | Metadane wideo (tytuł, czas trwania, platforma, napisy itd.) przez yt-dlp. |

### Nowe moduły

- `app/video/loader.py` — `VideoAudioLoader` (pobieranie audio przez yt-dlp z retry i obsługą proxy)
- `app/video/metadata.py` — ekstrakcja metadanych do modelu `VideoMetadata`
- `app/video/transcription.py` — `video_transcribe()` łączący loader z pipeline Whisper

### Schemat i migracja

- Nowy typ żądania `RequestType.VIDEO` w enumie i rejestracji procesów
- Migracja Alembic: `ALTER TYPE requesttype ADD VALUE 'VIDEO'`

### Ulepszenia towarzyszące

- **Autoryzacja OpenAPI**: zamiana `OAuth2PasswordBearer` na `HTTPBearer` — czytelniejsza dokumentacja Swagger z `persistAuthorization`
- **Podsumowania**: przebudowany prompt `DETAILED` (sekcje markdown: Summary, Referenced media, Guidelines, Examples, Tools)
- **README**: komendy Alembic i uruchamianie aplikacji przez `uv`
- **Testy**: `tests/test_video.py` — unit testy routera, loadera, metadanych i transkrypcji (mocki)

## Test plan

- [ ] `uv alembic upgrade head` — migracja `VIDEO` w enumie `requesttype` przechodzi bez błędów
- [ ] `uv run pytest tests/test_video.py -v` — wszystkie testy jednostkowe przechodzą
- [ ] `POST /auth/token` → token JWT
- [ ] `POST /video/details` z URL Vimeo/Instagram — zwraca `VideoMetadata`
- [ ] `POST /video/transcribe` z URL wideo — zwraca transkrypcję (SRT lub plain)
- [ ] `POST /video/summarize` — zwraca podsumowanie; nagłówek `Accept: text/srt` zwraca transkrypcję
- [ ] Swagger UI (`/docs`) — sekcja Bearer Auth działa, endpointy `/video/*` widoczne
- [ ] CI (`setup_and_test`) — zielony